### PR TITLE
centralize and clean file and io store logic

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -68,7 +68,7 @@ class VGCGLTest(TestCase):
         self._run(self.base_command, self.jobStoreLocal, self.test_vg_graph, self.sample_reads, 'NA12877',
                                    self.local_outstore, '--path_name', '17', '--path_size', '81189', '--call_opts', '--offset 43044293' )
 
-        self._assertOutput('17.vcf', self.local_outstore)
+        self._assertOutput('NA12877_17.vcf', self.local_outstore)
 
     @skip("Skipping lrc_kir test")
     def test_chr19_sampleNA12877(self):
@@ -82,7 +82,7 @@ class VGCGLTest(TestCase):
         self.test_index = os.path.join(self.workdir, 'lrc_kir_index.tar.gz')
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
                                    self.outstore,  '--gcsa_index', self.test_index, '--path_name', '19', '--path_size', '50000')
-        self._assertOutput('19.vcf', self.outstore)
+        self._assertOutput('NA12877_19.vcf', self.outstore)
 
     @skip("Skipping MHC test")
     def test_chr6_MHC_sampleNA12877(self):
@@ -93,7 +93,7 @@ class VGCGLTest(TestCase):
         self.test_index = 's3://cgl-pipeline-inputs/vg_cgl/ci/mhc_index.tar.gz'
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
                                    self.outstore,  '--gcsa_index', self.test_index, '--path_name', '6', '--path_size', '50000')
-        self._assertOutput('6.vcf', self.outstore)
+        self._assertOutput('NA12877_6.vcf', self.outstore)
 
     @skip("Skipping SMA test")
     def test_chr5_SMA_sampleNA12877(self):
@@ -107,7 +107,7 @@ class VGCGLTest(TestCase):
         self.test_index = os.path.join(self.workdir, 'sma_index.tar.gz')
         self._run(self.base_command, self.jobStoreAWS, self.test_vg_graph, self.sample_reads, 'NA12877',
                                    self.outstore, '--path_name', '5', '--path_size', '50000')
-        self._assertOutput('5.vcf', self.outstore)
+        self._assertOutput('NA12877_5.vcf', self.outstore)
     
     def _run(self, *args):
         args = list(concat(*args))
@@ -122,7 +122,8 @@ class VGCGLTest(TestCase):
         else:
             cp = ['cp']
             output_path = outstore
-        testName = testFile + '.gz'
+        # todo: clean this to be less hardcoded
+        testName = 'NA12877.vcf.gz'
         normalName = 'normal_' + testFile + '.gz'
         localTest = os.path.join(self.workdir, testName)
         localNormal = os.path.join(self.workdir, normalName)

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -50,6 +50,9 @@ def parse_args():
     parser.add_argument("--path_name", nargs='+', type=str,
         help="Name of reference path in the graph (eg. ref or 17)")    
 
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
+
     # Add indexing options
     index_parse_args(parser)
 
@@ -80,7 +83,6 @@ def index_parse_args(parser):
     parser.add_argument("--index_cores", type=int, default=3,
         help="number of threads during the indexing step")
 
-
 def run_indexing(job, options, inputGraphFileID):
     """
     Create a directory with the gcsa and xg indexe files and tar it up
@@ -103,7 +105,7 @@ def run_indexing(job, options, inputGraphFileID):
     robust_makedirs(graph_dir)
     
     graph_filename = "{}/graph.vg".format(graph_dir)
-    job.fileStore.readGlobalFile(inputGraphFileID, graph_filename)    
+    read_from_store(job, options, inputGraphFileID, graph_filename, use_out_store = False)    
     
     # Now run the indexer.
     RealTimeLogger.get().info("Indexing {}".format(options.vg_graph))


### PR DESCRIPTION
* add --force_outstore option to write all intermediate output files into the outstore for debuggin purposes
* otherwise clean up to only write final gams, index and vcf to the out store


