### PR TITLE
switch toil-vg map to use context instead of options

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -59,7 +59,7 @@ class VGCGLTest(TestCase):
         self.base_command = concat('toil-vg', 'run',
                                    '--realTimeLogging', '--logInfo', '--reads_per_chunk', '8000',
                                    '--call_chunk_size', '20000',
-                                   '--index_mode', 'gcsa-mem', '--gcsa_index_cores', '8', '--kmers_cores', '8',
+                                   '--gcsa_index_cores', '8', '--kmers_cores', '8',
                                    '--alignment_cores', '4',
                                    '--calling_cores', '4', '--vcfeval_cores', '4',
                                    '--vcfeval_opts', ' --ref-overlap',

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -367,12 +367,12 @@ def require(expression, message):
     if not expression:
         raise Exception('\n\n' + message + '\n\n')
 
-def parse_id_ranges(job, options, id_ranges_file_id):
+def parse_id_ranges(job, id_ranges_file_id):
     """Returns list of triples chrom, start, end
     """
     work_dir = job.fileStore.getLocalTempDir()
     id_range_file = os.path.join(work_dir, 'id_ranges.tsv')
-    read_from_store(job, options, id_ranges_file_id, id_range_file)
+    job.fileStore.readGlobalFile(id_ranges_file_id, id_range_file)
     return parse_id_ranges_file(id_range_file)
 
 def parse_id_ranges_file(id_ranges_filename):

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -178,16 +178,10 @@ single-reads-chunk: False
 # Each chunk will correspond to a vg map job
 reads-per-chunk: 10000000
 
-# Treat input fastq as paired-end interleaved
-interleaved: False
-
 # Core arguments for vg mapping (do not include file names or -t/--threads)
 # Note -i/--interleaved will be ignored. use the --interleaved option 
 # on the toil-vg command line instead
 map-opts: []
-
-# Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
-index-mode: gcsa-mem
 
 #########################
 ### vg_call Arguments ###
@@ -395,16 +389,10 @@ single-reads-chunk: False
 # Each chunk will correspond to a vg map job
 reads-per-chunk: 50000000
 
-# Treat input fastq as paired-end interleaved
-interleaved: False
-
 # Core arguments for vg mapping (do not include file names or -t/--threads)
 # Note -i/--interleaved will be ignored. use the --interleaved option 
 # on the toil-vg command line instead
 map-opts: []
-
-# Type of vg index to use for mapping (either 'gcsa-kmer' or 'gcsa-mem')
-index-mode: gcsa-mem
 
 #########################
 ### vg_call Arguments ###

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -36,9 +36,9 @@ def map_subparser(parser):
     
     parser.add_argument("sample_name", type=str,
         help="sample name (ex NA12878)")
-    parser.add_argument("xg_index", type=str,
+    parser.add_argument("xg_index", type=make_url,
         help="Path to xg index")    
-    parser.add_argument("gcsa_index", type=str,
+    parser.add_argument("gcsa_index", type=make_url,
         help="Path to GCSA index")
     parser.add_argument("out_store",
         help="output store.  All output written here. Path specified using same syntax as toil jobStore")
@@ -69,29 +69,39 @@ def map_parse_args(parser, stand_alone = False):
                         help="number of reads for each mapping job")
     parser.add_argument("--alignment_cores", type=int,
                         help="number of threads during the alignment step")
-    parser.add_argument("--index_mode", choices=["gcsa-kmer", "gcsa-mem"],
-                        help="type of vg index to use for mapping")
     parser.add_argument("--interleaved", action="store_true", default=False,
                         help="treat fastq as interleaved read pairs.  overrides map-args")
     parser.add_argument("--map_opts", type=str,
                         help="arguments for vg map (wrapped in \"\")")
 
-def run_mapping(job, options, xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id, reads_file_ids):
+def validate_map_options(options):
+    """
+    Throw an error if an invalid combination of options has been selected.
+    """                               
+    require(options.fastq is None or len(options.fastq) in [1, 2], 'Exacty 1 or 2 files must be'
+            ' passed with --fastq')
+    require(options.interleaved == False or options.fastq is None or len(options.fastq) == 1,
+            '--interleaved cannot be used when > 1 fastq given')
+    require((options.fastq and len(options.fastq)) != (options.gam_input_reads is not None),
+            'reads must be speficied with either --fastq or --gam_reads')
+    
+def run_mapping(job, context, fastq, gam_input_reads, sample_name, interleaved,
+                xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id, reads_file_ids):
     """ split the fastq, then align each chunk """
 
-    if not options.single_reads_chunk:
-        reads_chunk_ids = job.addChildJobFn(run_split_reads, options, reads_file_ids,
-                                            cores=options.misc_cores, memory=options.misc_mem,
-                                            disk=options.misc_disk).rv()
+    if not context.config.single_reads_chunk:
+        reads_chunk_ids = job.addChildJobFn(run_split_reads, context, fastq, gam_input_reads, reads_file_ids,
+                                            cores=context.config.misc_cores, memory=context.config.misc_mem,
+                                            disk=context.config.misc_disk).rv()
     else:
         RealtimeLogger.info("Bypassing reads splitting because --single_reads_chunk enabled")
         reads_chunk_ids = [reads_file_ids]
     
-    return job.addFollowOnJobFn(run_whole_alignment, options, xg_file_id, gcsa_and_lcp_ids,
-                                id_ranges_file_id, reads_chunk_ids, cores=options.misc_cores,
-                                memory=options.misc_mem, disk=options.misc_disk).rv()    
+    return job.addFollowOnJobFn(run_whole_alignment, context, fastq, gam_input_reads, sample_name, interleaved, xg_file_id, gcsa_and_lcp_ids,
+                                id_ranges_file_id, reads_chunk_ids, cores=context.config.misc_cores,
+                                memory=context.config.misc_mem, disk=context.config.misc_disk).rv()    
 
-def run_split_reads(job, options, reads_file_ids):
+def run_split_reads(job, context, fastq, gam_input_reads, reads_file_ids):
     """
     split either fastq or gam input reads into chunks.  returns list of chunk file id lists
     (one for each input reads file)
@@ -99,21 +109,21 @@ def run_split_reads(job, options, reads_file_ids):
 
     # this is a list of lists: one list of chunks for each input reads file
     reads_chunk_ids = []
-    if options.fastq and len(options.fastq):
+    if fastq and len(fastq):
         for fastq_i, reads_file_id in enumerate(reads_file_ids):
-            reads_chunk_ids.append(job.addChildJobFn(run_split_fastq, options, fastq_i, reads_file_id,
-                                                     cores=options.fq_split_cores,
-                                                     memory=options.fq_split_mem, disk=options.fq_split_disk).rv())
+            reads_chunk_ids.append(job.addChildJobFn(run_split_fastq, context, fastq, fastq_i, reads_file_id,
+                                                     cores=context.config.fq_split_cores,
+                                                     memory=context.config.fq_split_mem, disk=context.config.fq_split_disk).rv())
     else:
         assert len(reads_file_ids) == 1
-        reads_chunk_ids.append(job.addChildJobFn(run_split_gam_reads, options, reads_file_ids[0],
-                                                  cores=options.fq_split_cores,
-                                                  memory=options.fq_split_mem, disk=options.fq_split_disk).rv())
+        reads_chunk_ids.append(job.addChildJobFn(run_split_gam_reads, context, gam_input_reads, reads_file_ids[0],
+                                                  cores=context.config.fq_split_cores,
+                                                  memory=context.config.fq_split_mem, disk=context.config.fq_split_disk).rv())
 
     return reads_chunk_ids
 
 
-def run_split_fastq(job, options, fastq_i, sample_fastq_id):
+def run_split_fastq(job, context, fastq, fastq_i, sample_fastq_id):
     
     RealtimeLogger.info("Starting fastq split")
     start_time = timeit.default_timer()
@@ -122,14 +132,14 @@ def run_split_fastq(job, options, fastq_i, sample_fastq_id):
     work_dir = job.fileStore.getLocalTempDir()
 
     # We need the sample fastq for alignment
-    fastq_path = os.path.join(work_dir, os.path.basename(options.fastq[fastq_i]))
+    fastq_path = os.path.join(work_dir, os.path.basename(fastq[fastq_i]))
     fastq_gzipped = os.path.splitext(fastq_path)[1] == '.gz'
-    read_from_store(job, options, sample_fastq_id, fastq_path)
+    job.fileStore.readGlobalFile(sample_fastq_id, fastq_path)
 
     # Split up the fastq into chunks
 
     # Make sure chunk size even in case paired interleaved
-    chunk_size = options.reads_per_chunk
+    chunk_size = context.config.reads_per_chunk
     if chunk_size % 2 != 0:
         chunk_size += 1
 
@@ -144,15 +154,15 @@ def run_split_fastq(job, options, fastq_i, sample_fastq_id):
         cmd = [['cat', os.path.basename(fastq_path)]]
 
     cmd.append(['split', '-l', str(chunk_lines),
-                '--filter=pigz -p {} > $FILE.fq.gz'.format(max(1, int(options.fq_split_cores) - 1)),
+                '--filter=pigz -p {} > $FILE.fq.gz'.format(max(1, int(context.config.fq_split_cores) - 1)),
                 '-', 'fq_chunk.'])
 
-    options.drunner.call(job, cmd, work_dir = work_dir, tool_name='pigz')
+    context.runner.call(job, cmd, work_dir = work_dir, tool_name='pigz')
 
     fastq_chunk_ids = []
     for chunk_name in os.listdir(work_dir):
         if chunk_name.endswith('.fq.gz') and chunk_name.startswith('fq_chunk'):
-            fastq_chunk_ids.append(write_to_store(job, options, os.path.join(work_dir, chunk_name)))
+            fastq_chunk_ids.append(context.write_intermediate_file(job, os.path.join(work_dir, chunk_name)))
         
     end_time = timeit.default_timer()
     run_time = end_time - start_time
@@ -160,7 +170,7 @@ def run_split_fastq(job, options, fastq_i, sample_fastq_id):
 
     return fastq_chunk_ids
 
-def run_split_gam_reads(job, options, gam_reads_file_id):
+def run_split_gam_reads(job, context, gam_input_reads, gam_reads_file_id):
     """ split up an input reads file in GAM format
     """
     RealtimeLogger.info("Starting gam split")
@@ -170,13 +180,13 @@ def run_split_gam_reads(job, options, gam_reads_file_id):
     work_dir = job.fileStore.getLocalTempDir()
 
     # We need the sample fastq for alignment
-    gam_path = os.path.join(work_dir, os.path.basename(options.gam_input_reads))
-    read_from_store(job, options, gam_reads_file_id, gam_path)
+    gam_path = os.path.join(work_dir, os.path.basename(gam_input_reads))
+    job.fileStore.readGlobalFile(gam_reads_file_id, gam_path)
 
     # Split up the gam into chunks
 
     # Make sure chunk size even in case paired interleaved
-    chunk_size = options.reads_per_chunk
+    chunk_size = context.config.reads_per_chunk
     if chunk_size % 2 != 0:
         chunk_size += 1
 
@@ -187,12 +197,12 @@ def run_split_gam_reads(job, options, gam_reads_file_id):
     cmd.append(['split', '-l', str(chunk_lines),
                 '--filter=vg view -JaG - > $FILE.gam', '-', 'gam_reads_chunk.'])
 
-    options.drunner.call(job, cmd, work_dir = work_dir)
+    context.runner.call(job, cmd, work_dir = work_dir)
 
     gam_chunk_ids = []
     for chunk_name in os.listdir(work_dir):
         if chunk_name.endswith('.gam') and chunk_name.startswith('gam_reads_chunk'):
-            gam_chunk_ids.append(write_to_store(job, options, os.path.join(work_dir, chunk_name)))
+            gam_chunk_ids.append(context.write_intermediate_file(job, os.path.join(work_dir, chunk_name)))
         
     end_time = timeit.default_timer()
     run_time = end_time - start_time
@@ -200,7 +210,7 @@ def run_split_gam_reads(job, options, gam_reads_file_id):
 
     return gam_chunk_ids
     
-def run_whole_alignment(job, options, xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id, reads_chunk_ids):
+def run_whole_alignment(job, context, fastq, gam_input_reads, sample_name, interleaved, xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id, reads_chunk_ids):
     """ align all fastq chunks in parallel
     """
     
@@ -211,24 +221,22 @@ def run_whole_alignment(job, options, xg_file_id, gcsa_and_lcp_ids, id_ranges_fi
 
     for chunk_id, chunk_filename_ids in enumerate(zip(*reads_chunk_ids)):
         #Run graph alignment on each fastq chunk
-        gam_chunk_ids = job.addChildJobFn(run_chunk_alignment, options, chunk_filename_ids, chunk_id,
+        gam_chunk_ids = job.addChildJobFn(run_chunk_alignment, context, gam_input_reads, sample_name,
+                                          interleaved, chunk_filename_ids, chunk_id,
                                           xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id,
-                                          cores=options.alignment_cores, memory=options.alignment_mem,
-                                          disk=options.alignment_disk).rv()
+                                          cores=context.config.alignment_cores, memory=context.config.alignment_mem,
+                                          disk=context.config.alignment_disk).rv()
         gam_chunk_file_ids.append(gam_chunk_ids)
 
-    return job.addFollowOnJobFn(run_merge_gams, options, id_ranges_file_id, gam_chunk_file_ids,
-                                cores=options.misc_cores,
-                                memory=options.misc_mem, disk=options.misc_disk).rv()
+    return job.addFollowOnJobFn(run_merge_gams, context, sample_name, id_ranges_file_id, gam_chunk_file_ids,
+                                cores=context.config.misc_cores,
+                                memory=context.config.misc_mem, disk=context.config.misc_disk).rv()
 
 
-def run_chunk_alignment(job, options, chunk_filename_ids, chunk_id, xg_file_id, gcsa_and_lcp_ids,
-                        id_ranges_file_id):
+def run_chunk_alignment(job, context, gam_input_reads, sample_name, interleaved, chunk_filename_ids,
+                        chunk_id, xg_file_id, gcsa_and_lcp_ids, id_ranges_file_id):
 
-    RealtimeLogger.info("Starting alignment on {} chunk {}".format(options.sample_name, chunk_id))
-    # Set up the IO stores each time, since we can't unpickle them on Azure for
-    # some reason.
-    out_store = IOStore.get(options.out_store)
+    RealtimeLogger.info("Starting alignment on {} chunk {}".format(sample_name, chunk_id))
 
     # How long did the alignment take to run, in seconds?
     run_time = None
@@ -240,24 +248,24 @@ def run_chunk_alignment(job, options, chunk_filename_ids, chunk_id, xg_file_id, 
     graph_file = os.path.join(work_dir, "graph.vg")
 
     xg_file = graph_file + ".xg"
-    read_from_store(job, options, xg_file_id, xg_file)
+    job.fileStore.readGlobalFile(xg_file_id, xg_file)
     gcsa_file = graph_file + ".gcsa"
     gcsa_file_id = gcsa_and_lcp_ids[0]
-    read_from_store(job, options, gcsa_file_id, gcsa_file)
+    job.fileStore.readGlobalFile(gcsa_file_id, gcsa_file)
     lcp_file = gcsa_file + ".lcp"
     lcp_file_id = gcsa_and_lcp_ids[1]
-    read_from_store(job, options, lcp_file_id, lcp_file)
+    job.fileStore.readGlobalFile(lcp_file_id, lcp_file)
     
     # We need the sample reads (fastq(s) or gam) for alignment
     reads_files = []
-    reads_ext = 'gam' if options.gam_input_reads else 'fq.gz'
+    reads_ext = 'gam' if gam_input_reads else 'fq.gz'
     for j, chunk_filename_id in enumerate(chunk_filename_ids):
         reads_file = os.path.join(work_dir, 'reads_chunk_{}_{}.{}'.format(chunk_id, j, reads_ext))
-        read_from_store(job, options, chunk_filename_id, reads_file)
+        job.fileStore.readGlobalFile(chunk_filename_id, reads_file)
         reads_files.append(reads_file)
     
     # And a temp file for our aligner output
-    output_file = os.path.join(work_dir, "{}_{}.gam".format(options.sample_name, chunk_id))
+    output_file = os.path.join(work_dir, "{}_{}.gam".format(sample_name, chunk_id))
 
     # Open the file stream for writing
     with open(output_file, "w") as alignment_file:
@@ -266,38 +274,30 @@ def run_chunk_alignment(job, options, chunk_filename_ids, chunk_id, xg_file_id, 
 
         # Plan out what to run
         vg_parts = []
-        vg_parts += ['vg', 'map', '-t', str(options.alignment_cores)]
+        vg_parts += ['vg', 'map', '-t', str(context.config.alignment_cores)]
         for reads_file in reads_files:
-            input_flag = '-G' if options.gam_input_reads else '-f'
+            input_flag = '-G' if gam_input_reads else '-f'
             vg_parts += [input_flag, os.path.basename(reads_file)]
-        vg_parts += options.map_opts
+        vg_parts += context.config.map_opts
 
         # Override the -i flag in args with the --interleaved command-line flag
-        if options.interleaved is True and '-i' not in vg_parts and '--interleaved' not in vg_parts:
+        if interleaved is True and '-i' not in vg_parts and '--interleaved' not in vg_parts:
             vg_parts += ['-i']
-        elif options.interleaved is False and 'i' in vg_parts:
+        elif interleaved is False and 'i' in vg_parts:
             del vg_parts[vg_parts.index('-i')]
-        if options.interleaved is False and '--interleaved' in vg_parts:
+        if interleaved is False and '--interleaved' in vg_parts:
             del vg_parts[vg_parts.index('--interleaved')]
 
-        if options.index_mode == "gcsa-kmer":
-            # Use the new default context size in this case
-            vg_parts += ['-x', os.path.basename(xg_file), '-g', os.path.basename(gcsa_file),
-                '-k', str(options.kmer_size)]
-        elif options.index_mode == "gcsa-mem":
-            # Don't pass the kmer size, so MEM matching is used
-            vg_parts += ['-x', os.path.basename(xg_file), '-g', os.path.basename(gcsa_file)]
-        else:
-            raise RuntimeError("invalid indexing mode: " + options.index_mode)
+        vg_parts += ['-x', os.path.basename(xg_file), '-g', os.path.basename(gcsa_file)]
 
         RealtimeLogger.info(
-            "Running VG for {} against {}: {}".format(options.sample_name, graph_file,
+            "Running VG for {} against {}: {}".format(sample_name, graph_file,
             " ".join(vg_parts)))
         
         # Mark when we start the alignment
         start_time = timeit.default_timer()
         command = vg_parts
-        options.drunner.call(job, command, work_dir = work_dir, outfile=alignment_file)
+        context.runner.call(job, command, work_dir = work_dir, outfile=alignment_file)
         
         # Mark when it's done
         end_time = timeit.default_timer()
@@ -309,23 +309,23 @@ def run_chunk_alignment(job, options, chunk_filename_ids, chunk_id, xg_file_id, 
         # Break GAM into multiple chunks at the end. So we need the file
         # defining those chunks.
         id_ranges_file = os.path.join(work_dir, 'id_ranges.tsv')
-        read_from_store(job, options, id_ranges_file_id, id_ranges_file)
+        job.fileStore.readGlobalFile(id_ranges_file_id, id_ranges_file)
 
         # Chunk the gam up by chromosome
-        gam_chunks = split_gam_into_chroms(job, work_dir, options, xg_file, id_ranges_file, output_file)
+        gam_chunks = split_gam_into_chroms(job, work_dir, context, xg_file, id_ranges_file, output_file)
 
         # Write gam_chunks to store
         gam_chunk_ids = []
         for gam_chunk in gam_chunks:
-            gam_chunk_ids.append(write_to_store(job, options, gam_chunk))
+            gam_chunk_ids.append(context.write_intermediate_file(job, gam_chunk))
 
         return gam_chunk_ids
         
     else:
         # We can just report one chunk of everything
-        return [write_to_store(job, options, output_file)]
+        return [context.write_intermediate_file(job, output_file)]
 
-def split_gam_into_chroms(job, work_dir, options, xg_file, id_ranges_file, gam_file):
+def split_gam_into_chroms(job, work_dir, context, xg_file, id_ranges_file, gam_file):
     """
     Create a Rocksdb index then use it to split up the given gam file
     (a local path) into a separate gam for each chromosome.  
@@ -344,15 +344,15 @@ def split_gam_into_chroms(job, work_dir, options, xg_file, id_ranges_file, gam_f
     # index on coordinates (sort)
     output_index = gam_file + '.index'    
     index_cmd = ['vg', 'index', '-a', os.path.basename(gam_file),
-                 '-d', os.path.basename(output_index), '-t', str(options.gam_index_cores)]
-    options.drunner.call(job, index_cmd, work_dir = work_dir)
+                 '-d', os.path.basename(output_index), '-t', str(context.config.gam_index_cores)]
+    context.runner.call(job, index_cmd, work_dir = work_dir)
 
     # index on nodes in the alignments
     aln_index = gam_file + '.node.index'
     index_cmd = [['vg', 'index', '-A', '-d',  os.path.basename(output_index)]]
     index_cmd.append(['vg', 'index', '-N', '-', '-d', os.path.basename(aln_index),
-                      '-t', str(options.gam_index_cores)])
-    options.drunner.call(job, index_cmd, work_dir = work_dir)
+                      '-t', str(context.config.gam_index_cores)])
+    context.runner.call(job, index_cmd, work_dir = work_dir)
 
     # get rid of sort index
     shutil.rmtree(output_index)
@@ -369,10 +369,10 @@ def split_gam_into_chroms(job, work_dir, options, xg_file, id_ranges_file, gam_f
                  '-a', os.path.basename(aln_index), '-c', '0',
                  '-R', os.path.basename(cid_ranges_file),
                  '-b', os.path.splitext(os.path.basename(gam_file))[0],
-                 '-t', str(options.alignment_cores),
+                 '-t', str(context.config.alignment_cores),
                  '-E', os.path.basename(output_bed_name)]
     
-    options.drunner.call(job, chunk_cmd, work_dir = work_dir)
+    context.runner.call(job, chunk_cmd, work_dir = work_dir)
     
     # scrape up the vg chunk results into a list of paths to the output gam
     # chunks and return them.  we expect the filenames to be in the 4th column
@@ -388,14 +388,14 @@ def split_gam_into_chroms(job, work_dir, options, xg_file, id_ranges_file, gam_f
     return gam_chunks
 
 
-def run_merge_gams(job, options, id_ranges_file_id, gam_chunk_file_ids):
+def run_merge_gams(job, context, sample_name, id_ranges_file_id, gam_chunk_file_ids):
     """
     Merge together gams, doing each chromosome in parallel
     """
     
     if id_ranges_file_id is not None:
         # Get the real chromosome names
-        id_ranges = parse_id_ranges(job, options, id_ranges_file_id)
+        id_ranges = parse_id_ranges(job, id_ranges_file_id)
         chroms = [x[0] for x in id_ranges]
     else:
         # Dump everything in a single default chromosome chunk with a default
@@ -406,16 +406,16 @@ def run_merge_gams(job, options, id_ranges_file_id, gam_chunk_file_ids):
 
     for i, chr in enumerate(chroms):
         shard_ids = [gam_chunk_file_ids[j][i] for j in range(len(gam_chunk_file_ids))]
-        chr_gam_id = job.addChildJobFn(run_merge_chrom_gam, options, chr, shard_ids,
-                                       cores=options.fq_split_cores,
-                                       memory=options.fq_split_mem,
-                                       disk=options.fq_split_disk).rv()
+        chr_gam_id = job.addChildJobFn(run_merge_chrom_gam, context, sample_name, chr, shard_ids,
+                                       cores=context.config.fq_split_cores,
+                                       memory=context.config.fq_split_mem,
+                                       disk=context.config.fq_split_disk).rv()
         chr_gam_ids.append(chr_gam_id)
     
     return chr_gam_ids
 
 
-def run_merge_chrom_gam(job, options, chr_name, chunk_file_ids):
+def run_merge_chrom_gam(job, context, sample_name, chr_name, chunk_file_ids):
     """
     Make a chromosome gam by merging up a bunch of gam ids, one 
     for each  shard.  
@@ -423,87 +423,70 @@ def run_merge_chrom_gam(job, options, chr_name, chunk_file_ids):
     # Define work directory for docker calls
     work_dir = job.fileStore.getLocalTempDir()
     
-    output_file = os.path.join(work_dir, '{}_{}.gam'.format(options.sample_name, chr_name))
+    output_file = os.path.join(work_dir, '{}_{}.gam'.format(sample_name, chr_name))
 
     if len(chunk_file_ids) > 1:
         # Would be nice to be able to do this merge with fewer copies.. 
         with open(output_file, 'a') as merge_file:
             for chunk_gam_id in chunk_file_ids:
                 tmp_gam_file = os.path.join(work_dir, 'tmp_{}.gam'.format(uuid4()))
-                read_from_store(job, options, chunk_gam_id, tmp_gam_file)
+                job.fileStore.readGlobalFile(chunk_gam_id, tmp_gam_file)
                 with open(tmp_gam_file) as tmp_f:
                     shutil.copyfileobj(tmp_f, merge_file)
                 
-        chr_gam_id = write_to_store(job, options, output_file)
+        chr_gam_id = context.write_intermediate_file(job, output_file)
     else:
         chr_gam_id = chunk_file_ids[0]
                 
     # checkpoint to out store
-    if not options.force_outstore or options.tool == 'map':
-        if len(chunk_file_ids) == 1:
-            read_from_store(job, options, chunk_file_ids[0], output_file)
-        write_to_store(job, options, output_file, use_out_store = True)
-            
-    return chr_gam_id
+    if len(chunk_file_ids) == 1:
+        job.fileStore.readGlobalFile(chunk_file_ids[0], output_file)
+    return context.write_output_file(job, output_file)
 
-def map_main(options):
+def map_main(context, options):
     """
     Wrapper for vg map. 
     """
 
-    # make the docker runner
-    options.drunner = ContainerRunner(
-        container_tool_map = get_container_tool_map(options))
-
-    require(options.fastq is None or len(options.fastq) in [1, 2], 'Exacty 1 or 2 files must be'
-            ' passed with --fastq')
-    require(options.interleaved == False or options.fastq is None or len(options.fastq) == 1,
-            '--interleaved cannot be used when > 1 fastq given')
-    require((options.fastq and len(options.fastq)) != (options.gam_input_reads is not None),
-            'reads must be speficied with either --fastq or --gam_reads')
-    
-    # Some file io is dependent on knowing if we're in the pipeline
-    # or standalone. Hack this in here for now
-    options.tool = 'map'
-
-    # Throw error if something wrong with IOStore string
-    IOStore.get(options.out_store)
-    
+    validate_map_options(options)
+        
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None
         
     # Mark when we start the pipeline
     start_time_pipeline = timeit.default_timer()
-    
-    with Toil(options) as toil:
+
+    with context.get_toil(options.jobStore) as toil:
         if not toil.options.restart:
 
             start_time = timeit.default_timer()
             
             # Upload local files to the remote IO Store
-            inputXGFileID = import_to_store(toil, options, options.xg_index)
-            inputGCSAFileID = import_to_store(toil, options, options.gcsa_index)
-            inputLCPFileID = import_to_store(toil, options, options.gcsa_index + ".lcp")
+            inputXGFileID = toil.importFile(options.xg_index)
+            inputGCSAFileID = toil.importFile(options.gcsa_index)
+            inputLCPFileID = toil.importFile(options.gcsa_index + ".lcp")
             if options.id_ranges is not None:
-                inputIDRangesFileID = import_to_store(toil, options, options.id_ranges)
+                inputIDRangesFileID = toil.importFile(options.id_ranges)
             else:
                 inputIDRangesFileID = None
             inputReadsFileIDs = []
             if options.fastq:
                 for sample_reads in options.fastq:
-                    inputReadsFileIDs.append(import_to_store(toil, options, sample_reads))
+                    inputReadsFileIDs.append(toil.importFile(sample_reads))
             else:
-                inputReadsFileIDs.append(import_to_store(toil, options, options.gam_input_reads))
+                inputReadsFileIDs.append(toil.importFile(options.gam_input_reads))
             end_time = timeit.default_timer()
             logger.info('Imported input files into Toil in {} seconds'.format(end_time - start_time))
 
             # Make a root job
-            root_job = Job.wrapJobFn(run_mapping, options,inputXGFileID,
+            root_job = Job.wrapJobFn(run_mapping, context, options.fastq,
+                                     options.gam_input_reads, options.sample_name,
+                                     options.interleaved, inputXGFileID,
                                      (inputGCSAFileID, inputLCPFileID),
                                      inputIDRangesFileID, inputReadsFileIDs,
-                                     cores=options.misc_cores,
-                                     memory=options.misc_mem,
-                                     disk=options.misc_disk)
+                                     cores=context.config.misc_cores,
+                                     memory=context.config.misc_mem,
+                                     disk=context.config.misc_disk)
             
             # Run the job and store the returned list of output files to download
             toil.start(root_job)

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -658,11 +658,9 @@ def run_map_eval_align(job, context, options, index_ids, gam_names, gam_file_ids
         gam_file_ids = []
         # run vg map if requested
         for i, index_id in enumerate(index_ids):
-            # todo: clean up
-            map_opts = copy.deepcopy(options)
-            map_opts.sample_name = 'sample-{}'.format(i)
-            map_opts.interleaved = False
-            gam_file_ids.append(job.addChildJobFn(run_mapping, context.to_options(map_opts), index_id[0], index_id[1],
+            gam_file_ids.append(job.addChildJobFn(run_mapping, context, options.fastq,
+                                                  options.gam_input_reads, 'sample-{}'.format(i),
+                                                  False, index_id[0], index_id[1],
                                                   None, [reads_gam_file_id],
                                                   cores=context.config.misc_cores,
                                                   memory=context.config.misc_mem, disk=context.config.misc_disk).rv())
@@ -670,11 +668,9 @@ def run_map_eval_align(job, context, options, index_ids, gam_names, gam_file_ids
     if do_vg_mapping and options.vg_paired:
         # run paired end version of all vg inputs if --pe-gams specified
         for i, index_id in enumerate(index_ids):
-            # todo: clean up
-            map_opts_pe = copy.deepcopy(options)
-            map_opts_pe.sample_name = 'sample-pe-{}'.format(i)
-            map_opts_pe.interleaved = True
-            gam_file_ids.append(job.addChildJobFn(run_mapping, context.to_options(map_opts_pe), index_id[0], index_id[1],
+            gam_file_ids.append(job.addChildJobFn(run_mapping, context, options.fastq,
+                                                  options.gam_input_reads, 'sample-pe-{}'.format(i),
+                                                  True, index_id[0], index_id[1],
                                                   None, [reads_gam_file_id],
                                                   cores=context.config.misc_cores,
                                                   memory=context.config.misc_mem, disk=context.config.misc_disk).rv())


### PR DESCRIPTION
I'm just getting rid of "options" entirely, and passing parameters individually and as-needed in all but the very top level.  
A couple other related cleanups:
--interleaved removed from config file
--index_mode removed entirely (it's always gcsa-mem)


