### PR TITLE
Use same docker image for tabix and bcftools

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -126,10 +126,10 @@ container: """ + ("Docker" if test_docker() else "None") + """
 vg-docker: 'quay.io/vgteam/vg:v1.5.0-581-gc51e1acb-t67-run'
 
 # Docker container to use for bcftools
-bcftools-docker: 'quay.io/cmarkello/bcftools'
+bcftools-docker: 'vandhanak/bcftools:1.3.1'
 
 # Docker container to use for tabix
-tabix-docker: 'quay.io/cmarkello/htslib:latest'
+tabix-docker: 'vandhanak/bcftools:1.3.1'
 
 # Docker container to use for samtools
 samtools-docker: 'quay.io/ucsc_cgl/samtools:latest'
@@ -340,10 +340,10 @@ container: """ + ("Docker" if test_docker() else "None") + """
 vg-docker: 'quay.io/vgteam/vg:v1.5.0-581-gc51e1acb-t67-run'
 
 # Docker container to use for bcftools
-bcftools-docker: 'quay.io/cmarkello/bcftools'
+bcftools-docker: 'vandhanak/bcftools:1.3.1'
 
 # Docker container to use for tabix
-tabix-docker: 'quay.io/cmarkello/htslib:latest'
+tabix-docker: 'vandhanak/bcftools:1.3.1'
 
 # Docker container to use for samtools
 samtools-docker: 'quay.io/ucsc_cgl/samtools:latest'


### PR DESCRIPTION
This reduces disk space, and should help with Singularity's cache.  Am seeing a speedup on unit tests (from 10min for first to to 5min for first 2), but still not as fast as Docker (which runs in 3min)