### PR TITLE
Write toil-vg-info.txt from a job

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,9 +11,12 @@ virtualenv --never-download .env
 pip install --upgrade pip setuptools
 
 # Prepare directory for temp files
+# Sometimes the instances have un-deletable files in tmp, so we continue through errors
 TMPDIR=/mnt/ephemeral/tmp
+set +e
 rm -rf $TMPDIR
 mkdir $TMPDIR
+set -e
 export TMPDIR
 
 # Create s3am venv

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -13,6 +13,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -614,9 +615,12 @@ def call_main(context, options):
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
 
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)            
             
             # Run the job and store the returned list of output files to download
-            toil.start(root_job)
+            toil.start(init_job)
         else:
             toil.restart()
                 

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -20,7 +20,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
-from toil_vg.context import Context
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -456,9 +456,13 @@ def index_main(context, options):
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)            
             
             # Run the job and store the returned list of output files to download
-            index_key_and_id = toil.start(root_job)
+            index_key_and_id = toil.start(init_job)
         else:
             index_key_and_id = toil.restart()
             

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -21,6 +21,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -487,9 +488,13 @@ def map_main(context, options):
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)            
             
             # Run the job and store the returned list of output files to download
-            toil.start(root_job)
+            toil.start(init_job)
         else:
             toil.restart()
             

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -36,7 +36,7 @@ from toil_vg.vg_common import require, make_url, \
     add_common_vg_parse_args, add_container_tool_parse_args
 from toil_vg.vg_map import map_parse_args, run_mapping
 from toil_vg.vg_index import run_indexing
-from toil_vg.context import Context
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -1331,9 +1331,13 @@ def mapeval_main(context, options):
                                      plan.true_read_stats_file_id)
                 
             # Output files all live in the out_store, but if we wanted to we could export them also/instead.
-            
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(main_job)
+
             # Run the root job
-            toil.start(main_job)
+            toil.start(init_job)
         else:
             toil.restart()
             

--- a/src/toil_vg/vg_sim.py
+++ b/src/toil_vg/vg_sim.py
@@ -21,6 +21,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -266,9 +267,13 @@ def sim_main(context, options):
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)            
             
             # Run the job and store the returned list of output files to download
-            toil.start(root_job)
+            toil.start(init_job)
         else:
             toil.restart()
             

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -33,7 +33,7 @@ from toil_vg.vg_vcfeval import *
 from toil_vg.vg_config import *
 from toil_vg.vg_sim import *
 from toil_vg.vg_mapeval import *
-from toil_vg.context import Context
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -406,8 +406,12 @@ def pipeline_main(context, options):
                                      cores=context.config.misc_cores, memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
 
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)
+
             # Run the job and store
-            toil.start(root_job)
+            toil.start(init_job)
         else:
             toil.restart()
 

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -12,6 +12,7 @@ import logging
 from toil.common import Toil
 from toil.job import Job
 from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
 
@@ -199,8 +200,12 @@ def vcfeval_main(context, options):
                                      cores=context.config.vcfeval_cores, memory=context.config.vcfeval_mem,
                                      disk=context.config.vcfeval_disk)
 
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context)
+            init_job.addFollowOn(root_job)            
+
             # Run the job
-            f1 = toil.start(root_job)
+            f1 = toil.start(init_job)
         else:
             f1 = toil.restart()
 

--- a/version.py
+++ b/version.py
@@ -15,7 +15,7 @@
 version = '1.2.1a1'
 
 required_versions = {'pyyaml': '>=3.11',
-                     'boto3': '>=1.4.4',
+                     'boto3': '>=1.4.5',
                      'awscli': '>=1.10.1',
                      'tsv': '==1.2',
                      'scikit-learn': '==0.18.2'}


### PR DESCRIPTION
This is will move some out-store errors (that aren't file size related) to beginning of workflow, to save time  debugging #281 and related problems in the future.  