### PR TITLE
Change rocksdb api used for vg chunk

### DIFF
--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -449,16 +449,6 @@ def run_calling(job, context, xg_file_id, alignment_file_id, path_names, vcf_off
                  '-d', os.path.basename(gam_index_path), '-t', str(context.config.gam_index_cores)]
     context.runner.call(job, index_cmd, work_dir = work_dir)
 
-    # index on nodes in the alignments
-    aln_index_path = gam_path + '.node.index'
-    index_cmd = [['vg', 'index', '-A', '-d',  os.path.basename(gam_index_path)]]
-    index_cmd.append(['vg', 'index', '-N', '-', '-d', os.path.basename(aln_index_path),
-                      '-t', str(context.config.gam_index_cores)])
-    context.runner.call(job, index_cmd, work_dir = work_dir)
-
-    # get rid of sort index
-    shutil.rmtree(gam_index_path)
-
     # Write a list of paths
     path_list = os.path.join(work_dir, 'path_list.txt')
     offset_map = dict()
@@ -470,7 +460,7 @@ def run_calling(job, context, xg_file_id, alignment_file_id, path_names, vcf_off
     # Chunk the graph and gam, using the xg and rocksdb indexes
     output_bed_chunks_path = os.path.join(work_dir, 'output_bed_chunks_{}.bed'.format(tag))
     chunk_cmd = ['vg', 'chunk', '-x', os.path.basename(xg_path),
-                 '-a', os.path.basename(aln_index_path), '-c', str(context.config.chunk_context),
+                 '-a', os.path.basename(gam_index_path), '-c', str(context.config.chunk_context),
                  '-P', os.path.basename(path_list),
                  '-g',
                  '-s', str(context.config.call_chunk_size),

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -128,7 +128,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1159-g86001db8-t88-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1170-g11714735-t89-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -346,7 +346,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1159-g86001db8-t88-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1170-g11714735-t89-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -128,7 +128,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1111-g28d2c680-t85-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1159-g86001db8-t88-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -346,7 +346,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1111-g28d2c680-t85-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1159-g86001db8-t88-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'


### PR DESCRIPTION
Use the simple min-node->alignment index rather than looking up all nodes in the alignment.  Should make chunking much faster.  Not to be merged until mainline vg is updated with new vg chunk