### PR TITLE
Better error message when command not found

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -306,15 +306,16 @@ class VGCGLTest(TestCase):
         self._run('toil-vg', 'construct', self.jobStoreLocal, self.local_outstore,
                   '--fasta', in_fa, '--vcf', in_vcf, '--regions', in_region,
                   '--out_name', 'snp1kg-BRCA1', '--control_sample', 'HG00096',
-                  '--filter_ceph', '--realTimeLogging', '--logInfo')
+                  '--filter_ceph', '--realTimeLogging', '--logInfo',
+                  '--haplo_sample', 'HG00096')
 
         # This is a fairly superficial check without adding machinery to read vg files
         # Make sure output files exist and that they have expected relative sizes.
         # Todo: better correctness checks (maybe compare to hand-generated data?
         prev_vg_size = None
         prev_vcf_size = None
-        for ext in ['', '_filter', '_minus_HG00096', '_HG00096']:
-            if ext:
+        for ext in ['', '_filter', '_minus_HG00096', '_HG00096_haplo', '_HG00096']:
+            if ext and ext != '_HG00096_haplo':
                 vcf_file = os.path.join(self.local_outstore, '1kg_hg38-BRCA1{}.vcf.gz'.format(ext))
 
                 assert os.path.isfile(vcf_file)


### PR DESCRIPTION
Instead of  `OSError: [Errno 13] Permission denied`, print something like `RuntimeError: Command not found: vg` when local executable not found.  