### PR TITLE
Change mapeval error to warning

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -227,7 +227,7 @@ vcfeval-opts: []
 #########################
 ### sim and mapeval Arguments ###
 # Options to pass to vg sim (should not include -x, -n, -s or -a)
-sim-opts: ['-l', '100', '-p', '500', '-v', '50', '-e', '0.01', '-i', '0.002']
+sim-opts: ['-l', '150', '-p', '500', '-v', '50', '-e', '0.01', '-i', '0.002']
 
 # Options to pass to bwa
 bwa-opts: []
@@ -446,7 +446,7 @@ vcfeval-opts: []
 #########################
 ### sim and mapeval Arguments ###
 # Options to pass to vg sim (should not include -x, -n, -s or -a)
-sim-opts: ['-l', '100', '-p', '500', '-v', '50', '-e', '0.01', '-i', '0.002']
+sim-opts: ['-l', '150', '-p', '500', '-v', '50', '-e', '0.01', '-i', '0.002']
 
 # Options to pass to bwa
 bwa-opts: []

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -480,10 +480,16 @@ def compare_positions(job, context, truth_file_id, name, stats_file_id, mapeval_
             line_no += 1
             # every input has a true position
             true_read_name = true_fields[0]
-            if len(true_fields) != 3 or len(test_fields) != 5:
+            if len(true_fields) != 3:
+                # This seems to come up about one-in-a-million times from vg annotate as called
+                # by toil-vg sim.  Once it is fixed, we can turn this back into an error
+                logger.warning('Incorrect (!=3) true field counts on line {} for {}: {} and {}'.format(
+                    line_no, name, true_fields, test_fields))
+                continue
+            if len(test_fields) != 5:
                 # With the new TSV reader, the files should always have the
                 # correct field counts. Some fields just might be empty.
-                raise RuntimeError('Incorrect field counts on line {} for {}: {} and {}'.format(
+                raise RuntimeError('Incorrect (!=5) test field counts on line {} for {}: {} and {}'.format(
                     line_no, name, true_fields, test_fields))
             
             true_chr = true_fields[1]


### PR DESCRIPTION
Every now and then, a read doesn't get annotated with its true position.  Change this (hopefully temporarily) from an exception to an warning, so we can get some whole genome numbers. 