### PR TITLE
Use all paths for position comparison

### DIFF
--- a/src/toil_vg/vg_sim.py
+++ b/src/toil_vg/vg_sim.py
@@ -167,8 +167,10 @@ def run_sim_chunk(job, context, gam, seed, xg_file_id, xg_annot_file_id, chunk_i
 
         # turn the annotated gam json into truth positions, as separate command since
         # we're going to use a different docker container.  (Note, would be nice to
-        # avoid writing the json to disk)        
-        jq_cmd = ['jq', '-c', '-r', '[ .name, .refpos[0].name, .refpos[0].offset ] | @tsv',
+        # avoid writing the json to disk)
+        # note: in the following, we are writing the read name as the first column,
+        # then a path-name, path-offset in each successive pair of columns
+        jq_cmd = ['jq', '-c', '-r', '[ .name, (.refpos[] | .name, .offset) ] | @tsv',
                   os.path.basename(gam_annot_json)]
 
         # output truth positions


### PR DESCRIPTION
Need this for cactus yeast test.  If a graph maps a read correctly on an alternate path that's too far from the reference, still want to be able to count it.  So pull all path positions out of vg annotate ouput when doing comparison, and score as correct if a match found on any annotated path.   