### PR TITLE
Handle empty true refpos array

### DIFF
--- a/src/toil_vg/vg_sim.py
+++ b/src/toil_vg/vg_sim.py
@@ -204,7 +204,7 @@ def run_sim_chunk(job, context, gam, seed_base, xg_file_id, xg_annot_file_id, pa
         # avoid writing the json to disk)
         # note: in the following, we are writing the read name as the first column,
         # then a path-name, path-offset in each successive pair of columns
-        jq_cmd = ['jq', '-c', '-r', '[ .name, (.refpos[] | .name, .offset) ] | @tsv',
+        jq_cmd = ['jq', '-c', '-r', '[ .name, if .refpos != null then (.refpos[] | .name, .offset) else (null, null) end ] | @tsv',
                   os.path.basename(gam_annot_json)]
 
         # output truth positions


### PR DESCRIPTION
How we get true reads with empty refpos arrays is a worrying question, but it's definitely possible (if the graph has a bunch of off-path material, for example).