### PR TITLE
fix bwa map time bug

### DIFF
--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -749,7 +749,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids, reads_g
                                                       cores=context.config.alignment_cores, memory=context.config.alignment_mem,
                                                       disk=context.config.alignment_disk)
             bwa_bam_file_ids[1] = bwa_mem_job.rv(0)
-            bwa_mem_times[0] = bwa_mem_job.rv(1)
+            bwa_mem_times[1] = bwa_mem_job.rv(1)
 
     return out_gam_names, gam_file_ids, out_xg_ids, map_times, bwa_bam_file_ids, bwa_mem_times
     


### PR DESCRIPTION
typo caused pair and single end map times to get squashed together in map_times.tsv