### PR TITLE
Option to not re-index gams for genotype

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -353,7 +353,7 @@ class VGCGLTest(TestCase):
                   '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy',
                   '--genotype')
 
-        self._assertOutput('sample', self.local_outstore, f1_threshold=0.55)
+        self._assertOutput('sample', self.local_outstore, f1_threshold=0.95)
 
     def _run(self, *args):
         args = list(concat(*args))

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -128,7 +128,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1753-gb1a214aa-t109-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1766-gff48401d-t110-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -346,7 +346,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1753-gb1a214aa-t109-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-1766-gff48401d-t110-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'


### PR DESCRIPTION
As toil-vg is already pulling the relevant reads via vg chunk, it's wasteful to re-index the gams so vg genotype does the same thing. 