### PR TITLE
Switch to new vg calling interface

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -355,6 +355,24 @@ class VGCGLTest(TestCase):
 
         self._assertOutput('sample', self.local_outstore, f1_threshold=0.95)
 
+    def test_9_sim_small_genotype_no_augment(self):
+        ''' 
+        This is the same as test #1, but exercises --force_outstore.
+        '''
+        self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
+        self.test_vg_graph = self._ci_input_path('small.vg')
+        self.baseline = self._ci_input_path('small.vcf.gz')
+        self.chrom_fa = self._ci_input_path('small.fa.gz')
+
+        self._run(self.base_command, self.jobStoreLocal, 'sample',
+                  self.local_outstore,  '--fastq', self.sample_reads,
+                  '--graphs', self.test_vg_graph,
+                  '--chroms', 'x', '--vcfeval_baseline', self.baseline,
+                  '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy',
+                  '--genotype', '--no_augment')
+
+        self._assertOutput('sample', self.local_outstore, f1_threshold=0.95)        
+
     def _run(self, *args):
         args = list(concat(*args))
         log.info('Running %r', args)

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -128,7 +128,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1766-gff48401d-t110-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-2018-g71f96239-t119-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -346,7 +346,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker container to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.5.0-1766-gff48401d-t110-run'
+vg-docker: 'quay.io/vgteam/vg:v1.5.0-2018-g71f96239-t119-run'
 
 # Docker container to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -95,7 +95,7 @@ call-chunk-cores: 1
 call-chunk-mem: '4G'
 call-chunk-disk: '2G'
 
-# Resources for calling each chunk (currently includes pileup/call/genotype)
+# Resources for calling each chunk (currently includes augment/call/genotype)
 calling-cores: 1
 calling-mem: '4G'
 calling-disk: '2G'
@@ -207,8 +207,8 @@ chunk_context: 50
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
 filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
 
-# Options to pass to vg pileup. (do not include file names or -t/--threads)
-pileup-opts: ['-q', '10']
+# Options to pass to vg augment. (do not include any file names or -t/--threads)
+augment-opts: ['-q', '10', '-a', 'pileup']
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: []
@@ -313,7 +313,7 @@ call-chunk-cores: 8
 call-chunk-mem: '100G'
 call-chunk-disk: '100G'
 
-# Resources for calling each chunk (currently includes pileup/call/genotype)
+# Resources for calling each chunk (currently includes augment/call/genotype)
 calling-cores: 1
 calling-mem: '8G'
 calling-disk: '8G'
@@ -426,8 +426,8 @@ chunk_context: 50
 # Options to pass to chunk_gam. (do not include file names or -t/--threads)
 filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
 
-# Options to pass to vg pileup. (do not include file names or -t/--threads)
-pileup-opts: ['-q', '10']
+# Options to pass to vg augment. (do not include any file names or -t/--threads)
+augment-opts: ['-q', '10', '-a', 'pileup']
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: []
@@ -464,7 +464,7 @@ def apply_config_file_args(args):
 
     # turn --*_opts from strings to lists to be consistent with config file
     for x_opts in ['map_opts', 'call_opts', 'filter_opts', 'genotype_opts', 'vcfeval_opts', 'sim_opts',
-                   'bwa_opts', 'kmers_opts', 'gcsa_opts', 'mpmap_opts']:
+                   'bwa_opts', 'kmers_opts', 'gcsa_opts', 'mpmap_opts', 'augment_opts']:
         if x_opts in args.__dict__.keys() and type(args.__dict__[x_opts]) is str:
             args.__dict__[x_opts] = filter(lambda a : len(a), args.__dict__[x_opts].split(' '))
             # get rid of any -t or --threads while we're at it

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -254,6 +254,7 @@ def run_pipeline_call(job, context, options, xg_file_id, id_ranges_file_id, chr_
 
     vcf_tbi_wg_id_pair = job.addChildJobFn(run_all_calling, context, xg_file_id, chr_gam_ids, chroms,
                                            options.vcf_offsets, options.sample_name,
+                                           options.genotype, not options.no_augment,
                                            cores=context.config.misc_cores, memory=context.config.misc_mem,
                                            disk=context.config.misc_disk).rv()
 

--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '1.2.1a1'
+version = '1.3.1a1'
 
 required_versions = {'pyyaml': '>=3.11',
                      'boto3': '>=1.4.5',


### PR DESCRIPTION
The calling interface changed in vg here: https://github.com/vgteam/vg/pull/1256 to be more modular.  The main difference is that there's no more vg pileup, and graph augmentation is now done explicitly with its own command, vg augment.  The main benefit for toil-vg is that vg genotype should actually be runnable at genome scale now (to be tested shortly).

When this is merged, toil-vg will not be usable for calling with vg versions older than quay.io/vgteam/vg:v1.5.0-2018-g71f96239-t119-run (@cmarkello) 

