### PR TITLE
Allow the GBWT to be built during graph construction

### DIFF
--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -351,13 +351,9 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
             lcp_id = None
             
         if xg_index:
-            if gbwt_index:
-                # Build with the GBWT
-                
-                # We can only do this with one VCF.
-                assert(len(vcf_ids) == 1)
-                assert(len(tbi_ids) == 1)
-                
+            if gbwt_index and len(vcf_ids) == 1 and  len(tbi_ids) == 1:
+                # Build with the GBWT, but only if we have exactly one VCF.
+                # Some graphs (like primary) end up with no VCF and thus shouldn't get a GBWT
                 xg_job = construct_job.addFollowOnJobFn(run_xg_indexing, context, vg_ids,
                                                         vg_names, output_name_base,
                                                         vcf_phasing_file_id = vcf_ids[0],

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -364,8 +364,6 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                                           cores=context.config.xg_index_cores,
                                                           memory=context.config.xg_index_mem,
                                                           disk=context.config.xg_index_disk)
-        else:
-            xg_id = None
 
         output.append((vg_ids, vg_names, gcsa_id, lcp_id, xg_id))
     return output


### PR DESCRIPTION
We now have a `--gbwt_index` flag to vg construct. If you are using just one VCF and you are also doing `--xg_index`, you will get a GBWT file pre-built without having to run vg index.