### PR TITLE
Enable Snarl Cutting

### DIFF
--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -125,9 +125,21 @@ to do: Should go somewhere more central """
 
     def call(self, job, args, work_dir = '.' , outfile = None, errfile = None,
              check_output = False, tool_name=None):
-        """ run a command.  decide to use docker based on whether
-        its in the docker_tool_map.  args is either the usual argument list,
-        or a list of lists (in the case of a chain of piped commands)  """
+        """
+        
+        Run a command. Decide to use a container based on whether the tool
+        (either the tool of the first command, or the tool named by tool_name)
+        its in the container engine's tool map. Can handle args being either a
+        single list of string arguments (starting with the binary name) or a
+        list of such lists (in which case a pipeline is run, using no more than
+        one container).
+        
+        Redirects standard output and standard error to the file objects outfile
+        and errfile, if specified. If check_output is true, the call will block,
+        raise an exception on a nonzero exit status, and return standard
+        output's contents.
+        
+        """
         # from here on, we assume our args is a list of lists
         if len(args) == 0 or len(args) > 0 and type(args[0]) is not list:
             args = [args]

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -72,7 +72,7 @@ def construct_subparser(parser):
                         help="Make an xg index for each output graph")
     parser.add_argument("--gbwt_index", action="store_true",
                         help="Make a GBWT index alongside the xg index for each output graph")
-    parser.add_argument("--snarl_index", action="store_true",
+    parser.add_argument("--snarls_index", action="store_true",
                         help="Make an snarls file for each output graph")
     parser.add_argument("--haplo_sample", type=str,
                         help="Make haplotype thread graphs (for simulating from) for this sample")

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -370,10 +370,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                                       skip_xg=not xg_index, skip_gcsa=not gcsa_index,
                                                       skip_id_ranges=True, skip_snarls=not snarls_index,
                                                       make_gbwt=gbwt_index, haplo_pruning=False)
-        gcsa_id = indexing_job.rv('gcsa')
-        lcp_id = indexing_job.rv('lcp')
-        xg_id = indexing_job.rv('xg')
-        gbwt_id = indexing_job.rv('gbwt')
+        indexes = indexing_job.rv()    
 
         if gpbwt:
             assert(haplo_sample is not None)

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -434,7 +434,9 @@ def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name)
     pipeline = [['cat'] + graph_filenames, ['vg', 'snarls', '-']]
    
     with open(snarl_filename, "w") as snarl_file:
-        context.runner.call(job, pipeline, work_dir=work_dir, outfile=snarl_file)
+        # Concatenate all the graphs and compute the snarls.
+        # Make sure to do it all in the container for vg (and not for 'cat')
+        context.runner.call(job, pipeline, work_dir=work_dir, tool_name='vg', outfile=snarl_file)
 
     # Checkpoint index to output store
     snarl_file_id = context.write_output_file(job, snarl_filename)

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -403,7 +403,7 @@ def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name)
         graph_filenames.append(os.path.basename(graph_filename))
 
     # Where do we put the snarls?
-    snarl_filename = "{}.snarls".format(index_name)
+    snarl_filename = os.path.join(work_dir, "{}.snarls".format(index_name))
 
     # Now run the indexer.
     RealtimeLogger.info("Computing Snarls for {}".format(str(graph_filenames)))
@@ -414,7 +414,7 @@ def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name)
         context.runner.call(job, pipeline, work_dir=work_dir, outfile=snarl_file)
 
     # Checkpoint index to output store
-    snarl_file_id = context.write_output_file(job, os.path.join(work_dir, snarl_filename))
+    snarl_file_id = context.write_output_file(job, snarl_filename)
     
     end_time = timeit.default_timer()
     run_time = end_time - start_time

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -352,7 +352,19 @@ def run_xg_indexing(job, context, inputGraphFileIDs, graph_names, index_name,
     command = ['vg', 'index', '-t', str(job.cores), '-x', os.path.basename(xg_filename)]
     command += phasing_opts + graph_filenames
     
-    context.runner.call(job, command, work_dir=work_dir)
+    try:
+        context.runner.call(job, command, work_dir=work_dir)
+    except:
+        # Dump everything we need to replicate the index run
+        logging.error("XG indexing failed. Dumping files.")
+
+        for graph_filename in graph_filenames:
+            context.write_output_file(job, graph_filename)
+        if vcf_phasing_file_id:
+            context.write_output_file(job, phasing_file)
+            context.write_output_file(job, phasing_file + '.tbi')
+
+        raise
 
     # Checkpoint index to output store
     xg_file_id = context.write_output_file(job, os.path.join(work_dir, xg_filename))

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -396,7 +396,7 @@ def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name)
     # Now run the indexer.
     RealtimeLogger.info("Computing Snarls for {}".format(str(graph_filenames)))
 
-    pipeline = [['cat'] + graph_filenames, ['vg', 'snarls']]
+    pipeline = [['cat'] + graph_filenames, ['vg', 'snarls', '-']]
    
     with open(snarl_filename, "w") as snarl_file:
         context.runner.call(job, pipeline, work_dir=work_dir, outfile=snarl_file)

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -597,7 +597,7 @@ def run_indexing(job, context, inputGraphFileIDs,
                                                                      disk=context.config.xg_index_disk).rv()
 
         # now do the whole genome xg (without any gbwt)
-        if len(indexes['chrom_xg']) == 1 and not make_gpbwt:
+        if indexes.has_key('chrom_xg') and len(indexes['chrom_xg']) == 1 and not make_gpbwt:
             # our first chromosome is effectively the whole genome (note that above we
             # detected this and put in index_name so it's saved right (don't care about chrom names))
             indexes['xg'] = indexes['chrom_xg'][0]
@@ -631,6 +631,7 @@ def run_indexing(job, context, inputGraphFileIDs,
     chrom_xg_root_job.addFollowOn(gcsa_root_job)
     
     if not skip_gcsa:
+        # We know we made the per-chromosome indexes already, so we can use them here to make the GCSA
         gcsa_job = gcsa_root_job.addChildJobFn(run_gcsa_prep, context, inputGraphFileIDs,
                                                graph_names, index_name, chroms, indexes['chrom_xg'],
                                                indexes['chrom_gbwt'],

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -359,7 +359,7 @@ def run_xg_indexing(job, context, inputGraphFileIDs, graph_names, index_name,
         logging.error("XG indexing failed. Dumping files.")
 
         for graph_filename in graph_filenames:
-            context.write_output_file(job, graph_filename)
+            context.write_output_file(job, os.path.join(work_dir, graph_filename))
         if vcf_phasing_file_id:
             context.write_output_file(job, phasing_file)
             context.write_output_file(job, phasing_file + '.tbi')

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -462,7 +462,7 @@ def run_chunk_alignment(job, context, gam_input_reads, bam_input_reads, sample_n
         output_file, run_time, 'paired-end' if paired_end else 'single-end',
         'mpmap' if multipath else 'map'))
 
-    if indexes.has_key('id_ranges') is not None:
+    if indexes.has_key('id_ranges'):
         # Break GAM into multiple chunks at the end. So we need the file
         # defining those chunks.
         id_ranges_file = os.path.join(work_dir, 'id_ranges.tsv')

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -790,8 +790,7 @@ def run_map_eval_index(job, context, xg_file_ids, gcsa_file_ids, gbwt_file_ids, 
                                           'index', ['default'], 
                                           cores=context.config.misc_cores, memory=context.config.misc_mem,
                                           disk=context.config.misc_disk)
-            index_ids.append((index_job.rv(0), (index_job.rv(4), index_job.rv(5)),
-                              index_job.rv(2), index_job.rv(6)))
+            index_ids.append(index_job.rv())
     else:
         for i, xg_id in enumerate(xg_file_ids):
             # For each graph, gather and tag its indexes

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -186,7 +186,7 @@ def validate_options(options):
     # some options from toil-vg map are disabled on the command line
     # this can be eventually cleaned up a bit better 
     require(not options.interleaved,
-            '--interleaved disabled in toil-vg mapeval')
+            '--interleaved disabled in toil-vg mapeval; a single --fastq is always assumed interleaved and two are always assumed paired')
 
     # accept graphs or indexes in place of gams
     require(options.gams or options.index_bases or options.vg_graphs,

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -707,7 +707,7 @@ def run_map_eval_index(job, context, xg_file_ids, gcsa_file_ids, gbwt_file_ids, 
     
     """
 
-    # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
+    # index_ids are dicts from index type to file ID as returned by run_indexing
     index_ids = []
     if vg_file_ids:
         for vg_file_id in vg_file_ids:
@@ -740,7 +740,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
     """
 
     # scrape out the xg ids, don't need others any more after this step
-    xg_ids = [index_id[0] for index_id in index_ids]
+    xg_ids = [index_id['xg'] for index_id in index_ids]
 
     # the ids and names we pass forward
     out_xg_ids = xg_ids if gam_file_ids else []
@@ -769,12 +769,11 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
     if do_vg_mapping and singlepath and do_single:
         gam_file_ids = []
         # run vg map if requested
-        for i, index_id in enumerate(index_ids):
-            # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
+        for i, indexes in enumerate(index_ids):
             map_job = job.addChildJobFn(run_mapping, context, fq_names(reads_fastq_single_ids),
                                         None, None, 'aligned-{}'.format(gam_names[i]),
-                                        False, False, index_id[0], index_id[1], index_id[2],
-                                        None, reads_fastq_single_ids,
+                                        False, False, indexes,
+                                        reads_fastq_single_ids,
                                         cores=context.config.misc_cores,
                                         memory=context.config.misc_mem, disk=context.config.misc_disk)
             gam_file_ids.append(map_job.rv(0))
@@ -789,12 +788,11 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
         for opt_num, mpmap_opts in enumerate(mpmap_opts_list):
             mp_context = copy.deepcopy(context)
             mp_context.config.mpmap_opts = mpmap_opts
-            for i, index_id in enumerate(index_ids):
-                # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
+            for i, indexes in enumerate(index_ids):
                 map_job = job.addChildJobFn(run_mapping, mp_context, fq_names(reads_fastq_single_ids),
                                             None, None, 'aligned-{}-mp'.format(gam_names[i]),
-                                            False, True, index_id[0], index_id[1], index_id[2],
-                                            None, reads_fastq_single_ids,
+                                            False, True, indexes,
+                                            reads_fastq_single_ids,
                                             cores=mp_context.config.misc_cores,
                                             memory=mp_context.config.misc_mem, disk=mp_context.config.misc_disk)
                 gam_file_ids.append(map_job.rv(0))
@@ -806,12 +804,12 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
 
     if do_vg_mapping and do_paired and singlepath:
         # run paired end version of all vg inputs if --pe-gams specified
-        for i, index_id in enumerate(index_ids):
+        for i, indexes in enumerate(index_ids):
             # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
             map_job = job.addChildJobFn(run_mapping, context, fq_names(reads_fastq_paired_for_vg_ids),
                                         None, None, 'aligned-{}-pe'.format(gam_names[i]),
-                                        False, False, index_id[0], index_id[1], index_id[2],
-                                        None, reads_fastq_paired_for_vg_ids,
+                                        False, False, indexes,
+                                        reads_fastq_paired_for_vg_ids,
                                         cores=context.config.misc_cores,
                                         memory=context.config.misc_mem, disk=context.config.misc_disk)
             gam_file_ids.append(map_job.rv(0))
@@ -826,12 +824,11 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
         for opt_num, mpmap_opts in enumerate(mpmap_opts_list):
             mp_context = copy.deepcopy(context)
             mp_context.config.mpmap_opts = mpmap_opts
-            for i, index_id in enumerate(index_ids):
-                # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
+            for i, indexes in enumerate(index_ids):
                 map_job = job.addChildJobFn(run_mapping, mp_context, fq_names(reads_fastq_paired_for_vg_ids),
                                             None, None, 'aligned-{}-mp-pe'.format(gam_names[i]),
-                                            False, True, index_id[0], index_id[1], index_id[2],
-                                            None, reads_fastq_paired_for_vg_ids,
+                                            False, True, indexes,
+                                            reads_fastq_paired_for_vg_ids,
                                             cores=mp_context.config.misc_cores,
                                             memory=mp_context.config.misc_mem, disk=mp_context.config.misc_disk)
                 gam_file_ids.append(map_job.rv(0))

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -707,7 +707,7 @@ def run_map_eval_index(job, context, xg_file_ids, gcsa_file_ids, gbwt_file_ids, 
     
     """
 
-    # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges ) as returned by run_indexing
+    # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
     index_ids = []
     if vg_file_ids:
         for vg_file_id in vg_file_ids:
@@ -770,6 +770,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
         gam_file_ids = []
         # run vg map if requested
         for i, index_id in enumerate(index_ids):
+            # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
             map_job = job.addChildJobFn(run_mapping, context, fq_names(reads_fastq_single_ids),
                                         None, None, 'aligned-{}'.format(gam_names[i]),
                                         False, False, index_id[0], index_id[1], index_id[2],
@@ -789,6 +790,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
             mp_context = copy.deepcopy(context)
             mp_context.config.mpmap_opts = mpmap_opts
             for i, index_id in enumerate(index_ids):
+                # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
                 map_job = job.addChildJobFn(run_mapping, mp_context, fq_names(reads_fastq_single_ids),
                                             None, None, 'aligned-{}-mp'.format(gam_names[i]),
                                             False, True, index_id[0], index_id[1], index_id[2],
@@ -805,6 +807,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
     if do_vg_mapping and do_paired and singlepath:
         # run paired end version of all vg inputs if --pe-gams specified
         for i, index_id in enumerate(index_ids):
+            # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
             map_job = job.addChildJobFn(run_mapping, context, fq_names(reads_fastq_paired_for_vg_ids),
                                         None, None, 'aligned-{}-pe'.format(gam_names[i]),
                                         False, False, index_id[0], index_id[1], index_id[2],
@@ -824,6 +827,7 @@ def run_map_eval_align(job, context, index_ids, gam_names, gam_file_ids,
             mp_context = copy.deepcopy(context)
             mp_context.config.mpmap_opts = mpmap_opts
             for i, index_id in enumerate(index_ids):
+                # index_ids are of the form (xg, (gcsa, lcp), gbwt, id_ranges, snarls) as returned by run_indexing
                 map_job = job.addChildJobFn(run_mapping, mp_context, fq_names(reads_fastq_paired_for_vg_ids),
                                             None, None, 'aligned-{}-mp-pe'.format(gam_names[i]),
                                             False, True, index_id[0], index_id[1], index_id[2],

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -264,7 +264,7 @@ def run_pipeline_map(job, context, options, indexes, fastq_chunk_ids,
                                     cores=context.config.misc_cores, memory=context.config.misc_mem,
                                     disk=context.config.misc_disk).rv(0)
 
-    return job.addFollowOnJobFn(run_pipeline_call, context, options, indexes['xg'], indexes['id_ranges'],
+    return job.addFollowOnJobFn(run_pipeline_call, context, options, indexes['xg'], indexes.get('id_ranges'),
                                 chr_gam_ids, baseline_vcf_id, baseline_tbi_id,
                                 fasta_id, bed_id, cores=context.config.misc_cores, memory=context.config.misc_mem,
                                 disk=context.config.misc_disk).rv()

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -220,11 +220,12 @@ def run_pipeline_index(job, context, options, inputGraphFileIDs, inputReadsFileI
             indexes['gbwt'] = inputGBWTFileID
         
     if inputGCSAFileID is None:
-        (indexes['gcsa'], indexes['lcp']) = job.addChildJobFn(run_gcsa_prep, context, inputGraphFileIDs,
-                                                              map(os.path.basename, options.graphs),
-                                                              options.index_name, options.chroms,
-                                                              cores=context.config.misc_cores, memory=context.config.misc_mem,
-                                                              disk=context.config.misc_disk).rv()
+        gcsa_job = job.addChildJobFn(run_gcsa_prep, context, inputGraphFileIDs,
+                                     map(os.path.basename, options.graphs),
+                                     options.index_name, options.chroms,
+                                     cores=context.config.misc_cores, memory=context.config.misc_mem,
+                                     disk=context.config.misc_disk)
+        (indexes['gcsa'], indexes['lcp']) = (gcsa_job.rv(0), gcsa_job.rv(1))
     else:
         assert inputLCPFileID is not None
         (indexes['gcsa'], indexes['lcp']) = inputGCSAFileID, inputLCPFileID

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -205,7 +205,17 @@ def run_pipeline_index(job, context, options, inputGraphFileIDs, inputReadsFileI
                                   cores=context.config.misc_cores, memory=context.config.misc_mem,
                                   disk=context.config.misc_disk)
                                   
-    indexes = index_job.rv()
+    # Indexes is a promise for a dict, but we need to fill in some fields if
+    # they will come out as None. This would be super easy with nice thenable
+    # promises but we don't have those so we shall hack around it.
+
+    indexes = {}
+
+    indexes['xg'] = inputXGFileID if skip_xg else index_job.rv('xg')
+    indexes['gcsa'] = inputGCSAFileID if skip_gcsa else index_job.rv('gcsa')
+    indexes['lcp'] = inputLCPFileID if skip_gcsa else index_job.rv('lcp')
+    indexes['gbwt'] = inputGBWTFileID if inputGBWTFileID else index_job.rv('gbwt')
+    indexes['id_ranges'] = inputIDRangesFileID if skip_ranges else index_job.rv('id_ranges')
 
     if not options.single_reads_chunk:
         fastq_chunk_ids = job.addChildJobFn(run_split_reads, context, options.fastq,


### PR DESCRIPTION
This adds snarl indexing to the kinds of indexes we can make, and enables passing snarls to mpmap runs so that mpmap will use its snarl cutting feature.

Since I'm adding yet another kind of index file, I've refactored things to bundle up the indexes into a dict by string type (i.e. 'xg', 'id_ranges', etc.) instead of passing each around in its own positional parameter everywhere.