### PR TITLE
More index interface changes

### DIFF
--- a/scripts/construct-hs37d5-ec2.py
+++ b/scripts/construct-hs37d5-ec2.py
@@ -20,6 +20,7 @@ def parse_args(args):
     parser.add_argument("--gbwt", action="store_true", help="make gbwt")
     parser.add_argument("--xg", action="store_true", help="make xg")
     parser.add_argument("--gcsa", action="store_true", help="make gcsa")
+    parser.add_argument("--snarls", action="store_true", help="make snarls")
     parser.add_argument("--control", help="control sample")
     parser.add_argument("--primary", action="store_true", help="make primary graph")
     parser.add_argument("--minaf", type=float, help="make min allele filter graph")
@@ -76,6 +77,9 @@ if options.gcsa:
 
 if options.gbwt:
     cmd += ['--gbwt_index']
+
+if options.snarls:
+    cmd += ['--snarls_index']
 
 if options.control:
     cmd += ['--control_sample', options.control]

--- a/scripts/construct-hs37d5-ec2.py
+++ b/scripts/construct-hs37d5-ec2.py
@@ -18,7 +18,12 @@ def parse_args(args):
     parser.add_argument("--config", help="path of config on leader")
     parser.add_argument("--restart", action="store_true", help="resume toil workflow")
     parser.add_argument("--gbwt", action="store_true", help="make gbwt")
+    parser.add_argument("--xg", action="store_true", help="make xg")
+    parser.add_argument("--gcsa", action="store_true", help="make gcsa")
     parser.add_argument("--control", help="control sample")
+    parser.add_argument("--primary", action="store_true", help="make primary graph")
+    parser.add_argument("--minaf", type=float, help="make min allele filter graph")
+    
     parser.add_argument("--node", help="toil node type (default=r3.8xlarge:0.85)", default="r3.8xlarge:0.85")
     args = args[1:]        
     return parser.parse_args(args)
@@ -26,9 +31,12 @@ options = parse_args(sys.argv)
 
 def get_vcf_path_hs37d5(chrom):
     base = 'ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/'
-    if chrom in range(1, 23):
-        return os.path.join(base, 'ALL.chr{}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'.format(chrom))
-    elif chrom == 'X':
+    try:
+        if int(chrom) in range(1, 23):
+            return os.path.join(base, 'ALL.chr{}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz'.format(chrom))
+    except:
+        pass
+    if chrom == 'X':
         return os.path.join(base, 'ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz')
     elif chrom == 'Y':
         return os.path.join(base, 'ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz')
@@ -49,13 +57,22 @@ cmd = ['construct', options.job_store, options.out_store,
        '--fasta', get_fasta_path_hs37d5(),
        '--out_name', out_name,
        '--logFile', log_name,
-       '--primary',
-       '--alt_paths',
-       '--min_af', '0.034',
-       '--xg_index', '--gcsa_index']
+       '--alt_paths']
 
 # Note config file path is on the leader!!!!  Should fix to copy it over, but not sure how.
 cmd += ['--config', options.config] if options.config else ['--whole_genome_config']
+
+if options.minaf:
+    cmd += ['--min_af', str(options.minaf)]
+
+if options.primary:
+    cmd += ['--primary']
+
+if options.xg:
+    cmd += ['--xg_index']
+
+if options.gcsa:
+    cmd += ['--gcsa_index']
 
 if options.gbwt:
     cmd += ['--gbwt_index']
@@ -77,7 +94,7 @@ if options.restart:
     cmd += ['--restart']
 else:
     subprocess.check_call(['toil', 'clean', options.job_store])
-    
+
 print ' '.join(cmd)
 subprocess.check_call(['scripts/ec2-run.sh', '-n', options.node, options.leader, ' '.join(cmd)])
 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -103,7 +103,7 @@ class VGCGLTest(TestCase):
         self._run('toil-vg', 'index', self.jobStoreLocal, self.local_outstore,
                   '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8', '--kmers_cores', '8',
-                  '--realTimeLogging', '--logInfo', '--index_name', 'small')
+                  '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index')
 
         self._run('toil-vg', 'map', self.jobStoreLocal, 'sample',
                   os.path.join(self.local_outstore, 'small.xg'),
@@ -140,7 +140,7 @@ class VGCGLTest(TestCase):
         self._run('toil-vg', 'index', self.jobStoreLocal, self.local_outstore,
                   '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8', '--kmers_cores', '8',
-                  '--realTimeLogging', '--logInfo', '--index_name', 'small')
+                  '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index')
 
         self._run('toil-vg', 'sim', self.jobStoreLocal,
                  os.path.join(self.local_outstore, 'small.xg'), '2000',
@@ -448,7 +448,7 @@ class VGCGLTest(TestCase):
 
         # make a gbwt and xg index
         self._run('toil-vg', 'index', self.jobStoreLocal, self.local_outstore,
-                  '--skip_gcsa', '--graphs', vg_path, '--chroms', '17',
+                  '--xg_index', '--graphs', vg_path, '--chroms', '17',
                   '--vcf_phasing', in_vcf, '--index_name', 'my_index',
                   '--make_gbwt', '--xg_index_cores', '4')
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -167,14 +167,15 @@ freebayes-docker: 'maxulysse/freebayes:1.2.5'
 index-name: 'genome'
 
 # Options to pass to vg prune.
-# (limit to general parameters, currently -k, -e, s.  Rest decided by toil-vg via other options)
+# (limit to general parameters, currently -k, -e, s.  
+# Rest decided by toil-vg via other options like prune-mode)
 prune-opts: []
 
 # Options to pass to vg kmers.
-kmers-opts: ['-g', '-B', '-k', '16']
+kmers-opts: ['--gcsa-out', '--gcsa-binary', '--kmer-size', 16]
 
 # Options to pass to vg gcsa indexing
-gcsa-opts: ['-X', '3', '-Z', '3000']
+gcsa-opts: ['--size-limit', 3000, '--kmer-size', 16]
 
 ########################
 ### vg_map Arguments ###
@@ -388,14 +389,15 @@ freebayes-docker: 'maxulysse/freebayes:1.2.5'
 index-name: 'genome'
 
 # Options to pass to vg prune.
-# (limit to general parameters, currently -k, -e, s.  Rest decided by toil-vg via other options)
+# (limit to general parameters, currently -k, -e, s.  
+# Rest decided by toil-vg via other options like prune-mode)
 prune-opts: []
 
 # Options to pass to vg kmers.
-kmers-opts: ['-g', '-B', '-k', '16']
+kmers-opts: ['--gcsa-out', '--gcsa-binary', '--kmer-size', 16]
 
 # Options to pass to vg gcsa indexing
-gcsa-opts: ['-X', '3', '-Z', '3000']
+gcsa-opts: ['--size-limit', 3000, '--kmer-size', 16]
 
 ########################
 ### vg_map Arguments ###

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -50,10 +50,14 @@ construct-mem: '4G'
 construct-disk: '2G'
 
 # Resources allotted for xg indexing.
-# this stage generally cannot take advantage of more than one thread except GBWT
 xg-index-cores: 1
 xg-index-mem: '4G'
 xg-index-disk: '2G'
+
+# Resources allotted for xg indexing by chromosome (used for GBWT).
+gbwt-index-cores: 1
+gbwt-index-mem: '4G'
+gbwt-index-disk: '2G'
 
 # Resources allotted for gcsa pruning.  Note that the vg mod commands used in
 # this stage generally cannot take advantage of more than one thread
@@ -194,7 +198,7 @@ reads-per-chunk: 10000000
 map-opts: []
 
 # Core arguments for vg multipath mapping (do not include file names or -t/--threads)
-mpmap-opts: ['-S']
+mpmap-opts: ['--single-path-mode']
 
 #########################
 ### vg_call Arguments ###
@@ -230,7 +234,7 @@ vcfeval-opts: ['--ref-overlap', '--vcf-score-field', 'QUAL']
 #########################
 ### sim and mapeval Arguments ###
 # Options to pass to vg sim (should not include -x, -n, -s or -a)
-sim-opts: ['-l', '150', '-p', '570', '-v', '165', '-e', '0.01', '-i', '0.002']
+sim-opts: ['--read-length', '150', '--frag-len', '570', '--frag-std-dev', '165', '--sub-rate', '0.01', '--indel-rate', '0.002']
 
 # Options to pass to bwa
 bwa-opts: []
@@ -271,10 +275,14 @@ construct-mem: '32G'
 construct-disk: '32G'
 
 # Resources allotted for xg indexing.
-# this stage generally cannot take advantage of more than one thread except GBWT
-xg-index-cores: 32
+xg-index-cores: 2
 xg-index-mem: '200G'
 xg-index-disk: '200G'
+
+# Resources allotted for xg indexing by chromosome (used for GBWT).
+gbwt-index-cores: 2
+gbwt-index-mem: '64G'
+gbwt-index-disk: '100G'
 
 # Resources allotted for gcsa pruning.  Note that the vg mod commands used in
 # this stage generally cannot take advantage of more than one thread
@@ -416,7 +424,7 @@ reads-per-chunk: 50000000
 map-opts: []
 
 # Core arguments for vg multipath mapping (do not include file names or -t/--threads)
-mpmap-opts: ['-S']
+mpmap-opts: ['--single-path-mode']
 
 #########################
 ### vg_call Arguments ###
@@ -452,7 +460,7 @@ vcfeval-opts: ['--ref-overlap', '--vcf-score-field', 'QUAL']
 #########################
 ### sim and mapeval Arguments ###
 # Options to pass to vg sim (should not include -x, -n, -s or -a)
-sim-opts: ['-l', '150', '-p', '570', '-v', '165', '-e', '0.01', '-i', '0.002']
+sim-opts: ['--read-length', '150', '--frag-len', '570', '--frag-std-dev', '165', '--sub-rate', '0.01', '--indel-rate', '0.002']
 
 # Options to pass to bwa
 bwa-opts: []

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -22,7 +22,7 @@ from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
 from toil_vg.context import Context, run_write_info_to_outstore
-from toil_vg.vg_index import run_xg_indexing, run_indexing
+from toil_vg.vg_index import run_xg_indexing, run_indexing, index_parse_args, index_toggle_parse_args
 logger = logging.getLogger(__name__)
 
 # from ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/NA12878/analysis/Illumina_PlatinumGenomes_NA12877_NA12878_09162015/IlluminaPlatinumGenomes-user-guide.pdf
@@ -66,14 +66,6 @@ def construct_subparser(parser):
                         help="Filter out all variants specific to the CEPH pedigree, which includes NA12878")
     parser.add_argument("--filter_samples", nargs='+',
                         help="Filter out all variants specific to given samples")
-    parser.add_argument("--gcsa_index", action="store_true",
-                        help="Make a gcsa index for each output graph")
-    parser.add_argument("--xg_index", action="store_true",
-                        help="Make an xg index for each output graph")
-    parser.add_argument("--gbwt_index", action="store_true",
-                        help="Make a GBWT index alongside the xg index for each output graph")
-    parser.add_argument("--snarls_index", action="store_true",
-                        help="Make an snarls file for each output graph")
     parser.add_argument("--haplo_sample", type=str,
                         help="Make haplotype thread graphs (for simulating from) for this sample")
     parser.add_argument("--primary", action="store_true",
@@ -84,7 +76,8 @@ def construct_subparser(parser):
                         help="Create a control using the given minium allele frequency")
 
     # Add common indexing options shared with vg_index
-    index_parse_args(parser_run)
+    index_toggle_parse_args(parser)
+    index_parse_args(parser)
 
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)
@@ -830,10 +823,11 @@ def construct_main(context, options):
                                      options.flat_alts, regions,
                                      merge_graphs = options.merge_graphs,
                                      sort_ids = True, join_ids = True,
-                                     gcsa_index = options.gcsa_index, xg_index = options.xg_index,
-                                     gbwt_index = options.gbwt_index, snarls_index = options.snarls_index,
+                                     gcsa_index = options.gcsa_index or options.all_index,
+                                     xg_index = options.xg_index or options.all_index,
+                                     gbwt_index = options.gbwt_index or options.all_index,
+                                     snarls_index = options.snarls_index or options.all_index,
                                      haplo_sample = options.haplo_sample)
-                                     
             
             # Run the workflow
             toil.start(init_job)

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -317,7 +317,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                       max_node_size, alt_paths, flat_alts, regions,
                       merge_graphs = False, sort_ids = False, join_ids = False,
                       gcsa_index = False, xg_index = False, gbwt_index = False, snarls_index = False,
-                      haplo_sample = None, haplotypes = [0,1]):
+                      haplo_sample = None, haplotypes = [0,1], gbwt_prune = False):
     """ 
     construct many graphs in parallel, optionally doing indexing too. vcf_inputs
     is a list of tuples as created by run_generate_input_vcfs
@@ -365,7 +365,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                                       input_vcf_ids, input_tbi_ids,
                                                       skip_xg=not xg_index, skip_gcsa=not gcsa_index,
                                                       skip_id_ranges=True, skip_snarls=not snarls_index,
-                                                      make_gbwt=gbwt_index, haplo_pruning=False)
+                                                      make_gbwt=gbwt_index, gbwt_prune=gbwt_prune)
         indexes = indexing_job.rv()    
 
         if gpbwt:
@@ -828,7 +828,8 @@ def construct_main(context, options):
                                      xg_index = options.xg_index or options.all_index,
                                      gbwt_index = options.gbwt_index or options.all_index,
                                      snarls_index = options.snarls_index or options.all_index,
-                                     haplo_sample = options.haplo_sample)
+                                     haplo_sample = options.haplo_sample,
+                                     gbwt_prune = options.gbwt_prune)
             
             # Run the workflow
             toil.start(init_job)

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -82,7 +82,10 @@ def construct_subparser(parser):
                         help="Do not construct base graph from input vcf.  Only make optional controls")
     parser.add_argument("--min_af", type=float, default=None,
                         help="Create a control using the given minium allele frequency")
-    
+
+    # Add common indexing options shared with vg_index
+    index_parse_args(parser_run)
+
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)
 

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -98,15 +98,18 @@ def index_parse_args(parser):
     parser.add_argument("--gbwt_prune", action='store_true',
                         help="Use gbwt for gcsa pruning")
                         
-def validate_index_options(options, check_chroms=True):
+def validate_index_options(options, index_main):
     """
     Throw an error if an invalid combination of options has been selected.
     """
-    if check_chroms:
+    if index_main:
         require(options.chroms and options.graphs, '--chroms and --graphs must be specified')
         require(len(options.graphs) == 1 or len(options.chroms) == len(options.graphs),
                 '--chroms and --graphs must have'
                 ' same number of arguments if more than one graph specified')
+        require(any([options.xg_index, options.gcsa_index, options.snarls_index,
+                     options.id_ranges_index, options.gbwt_index, options.all_index]),
+                'at least one of --xg_index, --gcsa_index, --snarls_index, --id_ranged_index, --gbwt_index required, --all_index')        
     if options.vcf_phasing:
         require(all([vcf.endswith('.vcf.gz') for vcf in options.vcf_phasing]),
                 'input phasing files must end with .vcf.gz')
@@ -119,9 +122,6 @@ def validate_index_options(options, check_chroms=True):
             'only one of --make_gbwt and --gbwt_input can be used at a time')
     if options.gbwt_input:
         require(options.gbwt_prune == 'gbwt', '--gbwt_prune required with --gbwt_input')
-    require(any([options.xg_index, options.gcsa_index, options.snarls_index,
-                 options.id_ranges_index, options.gbwt_index, options.all_index]),
-            'at least one of --xg_index, --gcsa_index, --snarls_index, --id_ranged_index, --gbwt_index required, --all_index')
     
 def run_gcsa_prune(job, context, graph_name, input_graph_id, gbwt_id, mapping_id):
     """
@@ -680,7 +680,7 @@ def index_main(context, options):
     """
 
     # check some options
-    validate_index_options(options)
+    validate_index_options(options, True)
         
     # How long did it take to run the entire pipeline, in seconds?
     run_time_pipeline = None

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -127,6 +127,14 @@ def pipeline_subparser(parser_run):
         help="Path to file with node id ranges for each chromosome in BED format.  If not"
                             " supplied, will be generated from --graphs)")
 
+    parser_run.add_argument("--graphs", nargs='+', type=make_url,
+                        help="input graph(s). one per chromosome (separated by space)")
+
+    parser_run.add_argument("--chroms", nargs='+',
+                        help="Name(s) of reference path in graph(s) (separated by space).  If --graphs "
+                        " has multiple elements, must be same length/order as --chroms")
+
+
     # Add common options shared with everybody
     add_common_vg_parse_args(parser_run)
     
@@ -201,7 +209,6 @@ def run_pipeline_index(job, context, options, inputGraphFileIDs, inputReadsFileI
                                   vcf_phasing_file_ids = vcf_ids, tbi_phasing_file_ids = tbi_ids,
                                   skip_xg=skip_xg, skip_gcsa=skip_gcsa, skip_id_ranges=skip_ranges, skip_snarls=True,
                                   make_gbwt=False,
-                                  haplo_pruning=False,
                                   cores=context.config.misc_cores, memory=context.config.misc_mem,
                                   disk=context.config.misc_disk)
                                   


### PR DESCRIPTION
Update to work with latest vg (prune no longer takes xg, unfold requires gbwt), share indexing options between toil-vg index and toil-vg construct (replacing --skip_xg etc. from toil-vg index by --xg_index from construct)