### PR TITLE
Use toil 3.15 for Jenkins tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ check_build_reqs:
 
 prepare: check_venv
 	$(pip) install numpy scipy scikit-learn==0.18.2
-	$(pip) install pytest==2.8.3 'toil[aws,mesos]==3.13.0' biopython==1.67 pyvcf==0.6.8
+	# Note: we're installing toil[azure] below becauase toil 3.15.0 doesn't work without it
+	$(pip) install pytest==2.8.3 'toil[aws,mesos,azure]==3.15.0' biopython==1.67 pyvcf==0.6.8
 	pip list
 clean_prepare: check_venv
 	$(pip) uninstall -y pytest biopython numpy scipy scikit-learn pyvcf

--- a/version.py
+++ b/version.py
@@ -15,7 +15,7 @@
 version = '1.4.1a1'
 
 required_versions = {'pyyaml': '>=3.11',
-                     'boto3': '==1.6.7',
+                     'boto3': '>=1.4.7',
                      'tsv': '==1.2',
                      'scikit-learn': '==0.18.2',
                      'pyvcf': '==0.6.8'}


### PR DESCRIPTION
The docker caller doesn't work with the latest Toil.  This PR should demonstrate that