### PR TITLE
make running via ssh optional on ec2 scripts

### DIFF
--- a/scripts/calleval-ec2.py
+++ b/scripts/calleval-ec2.py
@@ -8,11 +8,11 @@ import os, sys, subprocess, argparse
 def parse_args(args):
     parser = argparse.ArgumentParser(description=__doc__, 
         formatter_class=argparse.RawDescriptionHelpFormatter)    
-    parser.add_argument("leader", help="name of leader created with create-ec2-leader.sh")
     parser.add_argument("job_store")
     parser.add_argument("out_store")
     parser.add_argument("basename", help="input file prefix.  will look for [outstore]/[basename].xg/gcsa,"
                         " [basename]_primary.xg/gcsa etc. as made by construct-hs37d5-ec2.py")
+    parser.add_argument("--leader", help="name of leader created with create-ec2-leader.sh")    
     parser.add_argument("--config", help="path of config on leader")
     parser.add_argument("--chroms", nargs='+', default=None,
                         help="chromosome(s) (default: everything in fasta)")
@@ -35,7 +35,7 @@ s3_outstore = options.out_store.replace('aws:us-west-2:', 's3://')
 me_outstore = os.path.join(options.out_store, options.outname)
 s3_me_outstore = me_outstore.replace('aws:us-west-2:', 's3://')
     
-log_name = '/calleval_{}.log'.format(os.path.basename(options.basename))
+log_name = 'calleval_{}.log'.format(os.path.basename(options.basename))
 os_log_name = os.path.join(s3_outstore, options.outname, os.path.basename(log_name))
 
 cmd = ['calleval', options.job_store, me_outstore,
@@ -73,12 +73,18 @@ if options.restart:
     cmd += ['--restart']
 else:
     subprocess.check_call(['toil', 'clean', options.job_store])
-    
-print ' '.join(cmd)
-subprocess.check_call(['scripts/ec2-run.sh', options.leader, ' '.join(cmd)])
+
+ec2_cmd = ['scripts/ec2-run.sh']
+if options.leader:
+    ec2_cmd += ['-l', options.leader]
+ec2_cmd += [' '.join(cmd)]
+
+print ' '.join(ec2_cmd)
+subprocess.check_call(ec2_cmd)
 
 #copy the log to the out store
-cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
-       '/venv/bin/aws', 's3', 'cp', log_name, os_log_name]
-print ' '.join(cmd)
-subprocess.check_call(cmd)
+if options.leader:
+    cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
+           '/venv/bin/aws', 's3', 'cp', log_name, os_log_name]
+    print ' '.join(cmd)
+    subprocess.check_call(cmd)

--- a/scripts/construct-hs37d5-ec2.py
+++ b/scripts/construct-hs37d5-ec2.py
@@ -10,9 +10,10 @@ import os, sys, subprocess, argparse
 def parse_args(args):
     parser = argparse.ArgumentParser(description=__doc__, 
         formatter_class=argparse.RawDescriptionHelpFormatter)    
-    parser.add_argument("leader", help="name of leader created with create-ec2-leader.sh")
     parser.add_argument("job_store")
     parser.add_argument("out_store")
+    parser.add_argument("--leader", help="name of leader created with create-ec2-leader.sh."
+                        "run on current machine if not specified")    
     parser.add_argument("--chroms", nargs='+', default=None,
                         help="chromosome(s) (default: everything in fasta)")
     parser.add_argument("--config", help="path of config on leader")
@@ -57,7 +58,7 @@ if not options.out_store.startswith('aws:'):
     options.out_store = 'aws:us-west-2:{}'.format(options.out_store)    
     
 out_name = 'snp1kg' if not options.chroms else 'snp1kg_{}'.format('_'.join(options.chroms))
-log_name = '/construct_{}.log'.format(out_name)
+log_name = 'construct_{}.log'.format(out_name)
 os_log_name = os.path.join(options.out_store[options.out_store.rfind(':')+1:], os.path.basename(log_name))
 
 cmd = ['construct', options.job_store, options.out_store,
@@ -116,13 +117,19 @@ if options.restart:
 else:
     subprocess.check_call(['toil', 'clean', options.job_store])
 
-print ' '.join(cmd)
-subprocess.check_call(['scripts/ec2-run.sh', '-n', options.node,
-                       '-m', options.max_node, options.leader, ' '.join(cmd)])
+
+ec2_cmd = ['scripts/ec2-run.sh', '-n', options.node, '-m', options.max_node]
+if options.leader:
+    ec2_cmd += ['-l', options.leader]
+ec2_cmd += [' '.join(cmd)]
+
+print ' '.join(ec2_cmd)
+subprocess.check_call(ec2_cmd)
 
 #copy the log to the out store
-cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
-       '/venv/bin/aws', 's3', 'cp', log_name, 's3://{}'.format(os_log_name)]
-print ' '.join(cmd)
-subprocess.check_call(cmd)
+if options.leader:
+    cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
+           '/venv/bin/aws', 's3', 'cp', log_name, 's3://{}'.format(os_log_name)]
+    print ' '.join(cmd)
+    subprocess.check_call(cmd)
 

--- a/scripts/mapeval-ec2.py
+++ b/scripts/mapeval-ec2.py
@@ -8,12 +8,12 @@ import os, sys, subprocess, argparse
 def parse_args(args):
     parser = argparse.ArgumentParser(description=__doc__, 
         formatter_class=argparse.RawDescriptionHelpFormatter)    
-    parser.add_argument("leader", help="name of leader created with create-ec2-leader.sh")
     parser.add_argument("job_store")
     parser.add_argument("out_store")
     parser.add_argument("basename", help="input file prefix.  will look for [outstore]/[basename].xg/gcsa,"
                         " [basename]_primary.xg/gcsa etc. as made by construct-hs37d5-ec2.py")
     parser.add_argument("truth_reads", help="annotated gam or bam to use as truth. if gam, .pos file needed too")
+    parser.add_argument("--leader", help="name of leader created with create-ec2-leader.sh")    
     parser.add_argument("--config", help="path of config on leader")
     parser.add_argument("--fasta", help="fasta. ideally already indexed with bwa index", required=True)
     parser.add_argument("--names", nargs="*", default=["primary", "minaf_0.034"],
@@ -32,7 +32,7 @@ if not options.out_store.startswith('aws:'):
 s3_outstore = options.out_store.replace('aws:us-west-2:', 's3://')
 me_outstore = os.path.join(options.out_store, options.outname)
     
-log_name = '/mapeval_{}.log'.format(os.path.basename(options.basename))
+log_name = 'mapeval_{}.log'.format(os.path.basename(options.basename))
 os_log_name = os.path.join(s3_outstore, options.outname, os.path.basename(log_name))
 
 cmd = ['mapeval', options.job_store, me_outstore,
@@ -70,12 +70,18 @@ if options.restart:
     cmd += ['--restart']
 else:
     subprocess.check_call(['toil', 'clean', options.job_store])
-    
-print ' '.join(cmd)
-subprocess.check_call(['scripts/ec2-run.sh', options.leader, ' '.join(cmd)])
+
+ec2_cmd = ['scripts/ec2-run.sh']
+if options.leader:
+    ec2_cmd += ['-l', options.leader]
+ec2_cmd += [' '.join(cmd)]
+
+print ' '.join(ec2_cmd)
+subprocess.check_call(ec2_cmd)
 
 #copy the log to the out store
-cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
-       '/venv/bin/aws', 's3', 'cp', log_name, os_log_name]
-print ' '.join(cmd)
-subprocess.check_call(cmd)
+if options.leader:
+    cmd = ['toil', 'ssh-cluster',  '--insecure', '--zone=us-west-2a', options.leader,
+           '/venv/bin/aws', 's3', 'cp', log_name, os_log_name]
+    print ' '.join(cmd)
+    subprocess.check_call(cmd)


### PR DESCRIPTION
Default will now be to run on current machine.  Using the `--leader` option will switch back to the old functionality of running on a remote leader via `toil ssh-cluster`