### PR TITLE
Allow running without a truth set when evaluation in mapeval is skipped

### DIFF
--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -246,8 +246,8 @@ def validate_options(options):
     require(options.gam_input_reads is None or options.bam_input_reads is None,
             '--gam_input_reads and --bam_input_reads cannot both be specified')
 
-    require(options.truth or options.bam_input_reads or options.gam_input_xg,
-            '--gam-input-xg must be used to specify xg index to annotate --gam_input_reads')
+    require(options.truth or options.skip_eval or options.bam_input_reads or options.gam_input_xg,
+            '--gam-input-xg must be provided to annotate reads, or reads must be input in BAM format or with associated truth')
     
 def parse_int(value):
     """

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -68,7 +68,9 @@ def add_mapeval_options(parser):
     # General options
     parser.add_argument('--truth', type=make_url, default=None,
                         help='list of true positions of reads as output by toil-vg sim'
-                        ' (by default positions extracted from --gam_input_reads or --bam_input_reads)')        
+                        ' (by default positions extracted from --gam_input_reads or --bam_input_reads)')
+    parser.add_argument('--skip-eval', action='store_true',
+                        help='skip evaluation, ignore --truth, and just map reads')
     parser.add_argument('--gams', nargs='+', type=make_url, default=[],
                         help='aligned reads to compare to truth.  specify xg index locations with --index-bases')
     parser.add_argument("--index-bases", nargs='+', type=make_url, default=[],
@@ -174,9 +176,9 @@ def validate_options(options):
     # Note that we have to accept --gams along with unaligned reads; in that
     # case we ignore the unaligned reads and use the pre-aligned GAMs.
 
-    # annotation is not an option when reading fastq
-    require(not options.fastq or options.truth,
-            '--truth required with --fastq input')
+    # annotation is not an option when reading fastq and doing evaluation
+    require(not options.fastq or (options.truth or options.skip_eval),
+            '--truth (or --skip-eval) required with --fastq input')
 
     # only one or two fastqs accepted
     require(not options.fastq or len(options.fastq) in [1,2],
@@ -1623,13 +1625,14 @@ def run_mapeval(job, context, options, xg_file_ids, gcsa_file_ids, gbwt_file_ids
     
     TODO: Refactor to use a list of dicts/dict of listys for the indexes.
     
-    Return the file IDs of result files.
-    
     Returns a pair of the position comparison results and the score comparison
     results.
     
     Each result set is itself a pair, consisting of a list of per-graph file
     IDs, and an overall statistics file ID.
+
+    If evaluation is skipped (options.skip_eval is True), returns None instead
+    and just runs the mapping.
     
     """
     
@@ -1740,11 +1743,19 @@ def run_mapeval(job, context, options, xg_file_ids, gcsa_file_ids, gbwt_file_ids
         alignment_job.rv(0), alignment_job.rv(1), alignment_job.rv(2),
         alignment_job.rv(3), alignment_job.rv(4), alignment_job.rv(5))
 
+
     # We make a root for comparison here to encapsulate its follow-on chain
     comparison_parent_job = Job()
     alignment_job.addFollowOn(comparison_parent_job)
+
+    # Dump out the running times into map_times.tsv
+    comparison_parent_job.addChildJobFn(run_write_map_times, context, gam_names, vg_map_times, bwa_map_times)
+
+    if options.skip_eval:
+        # Skip evaluation
+        return None
     
-    # Then do mapping evaluation comparison (the rest of the workflow)
+    # Otherwise, do mapping evaluation comparison (the rest of the workflow)
     comparison_job = comparison_parent_job.addChildJobFn(run_map_eval_comparison, context, xg_ids,
                      gam_names, gam_file_ids, options.bam_names, bam_file_ids,
                      options.pe_bam_names, pe_bam_file_ids, bwa_bam_file_ids,
@@ -1767,9 +1778,6 @@ def run_mapeval(job, context, options, xg_file_ids, gcsa_file_ids, gbwt_file_ids
     plot_job = comparison_parent_job.addFollowOnJobFn(run_map_eval_plot, context,
                                                       position_comparison_results, score_comparison_results, plot_sets)
 
-    # Dump out the running times into map_times.tsv
-    comparison_parent_job.addChildJobFn(run_write_map_times, context, gam_names, vg_map_times, bwa_map_times)
-                     
     return comparison_job.rv()
 
 def run_map_eval_plot(job, context, position_comp_results, score_comp_results, plot_sets):


### PR DESCRIPTION
This lets you use mapeval to just run a bunch of different map conditions (e.g. on real reads).