### PR TITLE
Double whole-genome calling job size

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -316,9 +316,9 @@ call-chunk-mem: '100G'
 call-chunk-disk: '100G'
 
 # Resources for calling each chunk (currently includes augment/call/genotype)
-calling-cores: 2
-calling-mem: '32G'
-calling-disk: '8G'
+calling-cores: 4
+calling-mem: '64G'
+calling-disk: '16G'
 
 # Resources for vcfeval
 vcfeval-cores: 32


### PR DESCRIPTION
The old settings were set on ~30x data, but I am now running simulations up to
~60x, and I ran out of memory.