### PR TITLE
hap.py support

### DIFF
--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -239,13 +239,21 @@ def run_calleval_results(job, context, names, vcf_tbi_pairs, eval_results, happy
     # make a simple tsv
     stats_path = os.path.join(work_dir, 'calleval_stats.tsv')
     with open(stats_path, 'w') as stats_file:
-        for name, eval_result, in zip(names, eval_results):
+        for name, eval_result, happy_result in zip(names, eval_results, happy_results):
             # Find the best result (clipped if present, unclipped if not).
             # The best is the last non-None one.
             best_result = [r for r in eval_result if r is not None][-1]
-        
+
+            # Same for the happy results
+            happy_non_none_results = [r for r in happy_result if r is not None]
+            if happy_non_none_results:
+                happy_snp_f1 = happy_non_none_results[-1][0]['SNP']['METRIC.F1_Score']
+                happy_indel_f1 = happy_non_none_results[-1][0]['INDEL']['METRIC.F1_Score']
+            else:
+                happy_snp_f1, happy_indel_f1 = -1, -1
+                
             # Output the F1 score (first element)
-            stats_file.write('{}\t{}\n'.format(name, best_result[0]))
+            stats_file.write('{}\t{}\t{}\t{}\n'.format(name, best_result[0], happy_snp_f1, happy_indel_f1))
 
     # Replace Nones in the list of plot sets with "subsets" of all the condition names
     plot_sets = [plot_set if plot_set is not None else names for plot_set in plot_sets]

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -82,6 +82,7 @@ def get_container_tool_map(options):
     cmap[0]["Rscript"] = options.r_docker
     cmap[0]["vcfremovesamples"] = options.vcflib_docker
     cmap[0]["freebayes"] = options.freebayes_docker
+    cmap[0]['hap.py'] = options.happy_docker
      
     # to do: could be a good place to do an existence check on these tools
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -161,6 +161,9 @@ vcflib-docker: 'quay.io/biocontainers/vcflib:1.0.0_rc1--0'
 # Docker image to use for Freebayes
 freebayes-docker: 'maxulysse/freebayes:1.2.5'
 
+# Docker image to use for hap.py
+happy-docker: 'donfreed12/hap.py:v0.3.9'
+
 ##########################
 ### vg_index Arguments ###
 
@@ -379,6 +382,9 @@ vcflib-docker: 'quay.io/biocontainers/vcflib:1.0.0_rc1--0'
 
 # Docker image to use for Freebayes
 freebayes-docker: 'maxulysse/freebayes:1.2.5'
+
+# Docker image to use for hap.py
+happy-docker: 'donfreed12/hap.py:v0.3.9'
 
 ##########################
 ### vg_index Arguments ###

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -58,11 +58,13 @@ def vcfeval_parse_args(parser):
                         help="Cores to use for vcfeval")
     parser.add_argument("--vcfeval_score_field", default=None,
                         help="vcf FORMAT field to use for ROC score.  overrides vcfeval_opts")
+    parser.add_argument("--happy", action="store_true",
+                        help="run hap.py comparison in addition to rtg vcfeval")
 
 def validate_vcfeval_options(options):
     """ check some options """
     # we can relax this down the road by optionally doing some compression/indexing
-    assert options.vcfeval_baseline.endswith(".vcf.gz")
+    assert options.vcfeval_baseline and options.vcfeval_baseline.endswith(".vcf.gz")
     assert options.call_vcf.endswith(".vcf.gz")
 
     assert options.vcfeval_fasta
@@ -136,7 +138,8 @@ def run_vcfeval_roc_plot(job, context, roc_table_ids, names=[], title=None, show
     context.runner.call(job, roc_cmd, work_dir = work_dir)
 
     return context.write_output_file(job, out_roc_path, os.path.join('plots', plot_filename))
-    
+
+
 def run_vcfeval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeval_baseline_tbi_id, 
     fasta_path, fasta_id, bed_id, out_name = None, score_field=None):
     """ run vcf_eval, return (f1 score, summary id, output archive id, snp-id, nonsnp-id, weighted-id)"""
@@ -252,6 +255,89 @@ def run_vcfeval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
 
     return [f1, out_summary_id, out_archive_id] + out_roc_ids
 
+def run_happy(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeval_baseline_tbi_id, 
+              fasta_path, fasta_id, bed_id, fasta_idx_id = None, out_name = None):
+    """ run vcf_eval, return (f1 score, summary id, output archive id, snp-id, nonsnp-id, weighted-id)"""
+
+    # make a local work directory
+    work_dir = job.fileStore.getLocalTempDir()
+
+    # download the vcf
+    call_vcf_id, call_tbi_id = vcf_tbi_id_pair[0], vcf_tbi_id_pair[1]
+    call_vcf_name = "calls.vcf.gz"
+    job.fileStore.readGlobalFile(vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
+    job.fileStore.readGlobalFile(vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
+
+    # and the truth vcf
+    vcfeval_baseline_name = 'truth.vcf.gz'
+    job.fileStore.readGlobalFile(vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
+    job.fileStore.readGlobalFile(vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
+    
+    # download the fasta (make sure to keep input extension)
+    fasta_name = "fa_" + os.path.basename(fasta_path)
+    job.fileStore.readGlobalFile(fasta_id, os.path.join(work_dir, fasta_name))
+
+    # download or create the fasta index which is required by hap.py
+    if fasta_idx_id:
+        job.fileStore.readGlobalFile(fasta_idx_id, os.path.join(work_dir, fasta_name + '.fai'))
+    else:
+        context.runner.call(job, ['samtools', 'faidx', fasta_name], work_dir=work_dir)
+
+    # download the bed regions
+    bed_name = "bed_regions.bed" if bed_id else None
+    if bed_id:
+        job.fileStore.readGlobalFile(bed_id, os.path.join(work_dir, bed_name))
+
+    # use out_name if specified, otherwise sample
+    if sample and not out_name:
+        out_name = sample        
+    if out_name:
+        out_tag = '{}_happy'.format(out_name)
+    else:
+        out_tag = 'happy_output'
+        
+    # output directory
+    out_name = os.path.join(out_tag, 'happy')
+    os.makedirs(os.path.join(work_dir, out_tag))
+    
+    # run the vcf_eval command
+    cmd = ['hap.py', vcfeval_baseline_name, call_vcf_name,
+           '--report-prefix', out_name, '--reference', fasta_name, '--write-vcf', '--write-counts', '--no-roc']
+
+    if bed_name:
+        cmd += ['--false-positives', bed_name]
+        
+    try:
+        context.runner.call(job, cmd, work_dir=work_dir)
+    except:
+        # Dump everything we need to replicate the alignment
+        logging.error("hap.py VCF evaluation failed. Dumping files.")
+        context.write_output_file(job, os.path.join(work_dir, call_vcf_name))
+        context.write_output_file(job, os.path.join(work_dir, vcfeval_baseline_name))
+        # TODO: Dumping the sdf folder doesn't seem to work right. But we can dump the fasta
+        context.write_output_file(job, os.path.join(work_dir, fasta_name))
+        if bed_name is not None:
+            context.write_output_file(job, os.path.join(work_dir, bed_name))
+        
+        raise
+
+
+    # copy results to outstore 
+    
+    # happy_output_summary.csv
+    out_summary_id = context.write_output_file(job, os.path.join(work_dir, out_name + '.summary.csv'),
+                                               out_store_path = '{}_summary.csv'.format(out_tag))
+
+    # happy_output.tar.gz -- whole shebang
+    context.runner.call(job, ['tar', 'czf', out_tag + '.tar.gz', out_tag], work_dir = work_dir)
+    out_archive_id = context.write_output_file(job, os.path.join(work_dir, out_tag + '.tar.gz'))
+
+    # truth VCF
+    context.write_output_file(job, os.path.join(work_dir, vcfeval_baseline_name))
+    context.write_output_file(job, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
+    
+    return out_summary_id, out_archive_id
+
 def vcfeval_main(context, options):
     """ command line access to toil vcf eval logic"""
 
@@ -280,17 +366,25 @@ def vcfeval_main(context, options):
             logger.info('Imported input files into Toil in {} seconds'.format(end_time - start_time))
 
             # Make a root job
-            root_job = Job.wrapJobFn(run_vcfeval, context, None,
-                                     (call_vcf_id, call_tbi_id),
-                                     vcfeval_baseline_id, vcfeval_baseline_tbi_id,
-                                     options.vcfeval_fasta, fasta_id, bed_id,
-                                     score_field=options.vcfeval_score_field,
-                                     cores=context.config.vcfeval_cores, memory=context.config.vcfeval_mem,
-                                     disk=context.config.vcfeval_disk)
+            vcfeval_job = Job.wrapJobFn(run_vcfeval, context, None,
+                                        (call_vcf_id, call_tbi_id),
+                                        vcfeval_baseline_id, vcfeval_baseline_tbi_id,
+                                        options.vcfeval_fasta, fasta_id, bed_id,
+                                        score_field=options.vcfeval_score_field,
+                                        cores=context.config.vcfeval_cores, memory=context.config.vcfeval_mem,
+                                        disk=context.config.vcfeval_disk)
 
             # Init the outstore
             init_job = Job.wrapJobFn(run_write_info_to_outstore, context, sys.argv)
-            init_job.addFollowOn(root_job)            
+            init_job.addFollowOn(vcfeval_job)
+            if options.happy:
+                happy_job = Job.wrapJobFn(run_happy, context, None,
+                                          (call_vcf_id, call_tbi_id),
+                                          vcfeval_baseline_id, vcfeval_baseline_tbi_id,
+                                          options.vcfeval_fasta, fasta_id, bed_id,
+                                          cores=context.config.vcfeval_cores, memory=context.config.vcfeval_mem,
+                                          disk=context.config.vcfeval_disk)
+                init_job.addFollowOn(happy_job)
 
             # Run the job
             f1 = toil.start(init_job)

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -104,7 +104,7 @@ def parse_happy_summary(summary_path):
             assert cat not in results
             results[cat] = {}
             for column in range(1, len(header)):
-                results[cat][header[column]] = row[column]
+                results[cat][header[column]] = row[column] if len(row[column]) else '0'
         return results
 
 def run_vcfeval_roc_plot(job, context, roc_table_ids, names=[], title=None, show_scores=False,


### PR DESCRIPTION
vcfeval's breakdown into snps and indels (done in roc plots) seems unduly dependent on vcf representation issues at times.  hap.py doesn't make roc plots as easily, but its summary table often seems to give a more robust sense of snp vs. indel performance.  solution: start incorporating hap.py into all results tables...

There are a few hap.py docker images out there and pkrusche/hap.py seems the most official, but the only one I can get to work with apiDockerCall is donfreed12/hap.py. 