### PR TITLE
Get toil-vg working with vg jenkins again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ kwargs = dict(
     install_requires=[x + y for x, y in required_versions.iteritems()],
     dependency_links=[],
     # The tests need the optional numpy and scipy dependencies in addition to the actual dependencies
-    tests_require=['pytest==2.8.3', 'numpy>=1.9.1,<=1.14.2', 'scipy>=0.14.0,<=1.0.0'],
+    tests_require=['pytest==2.8.3', 'numpy>=1.9.1', 'scipy>=0.14.0,<=1.0.0'],
     package_dir={'': 'src'},
     packages=find_packages('src'),
     entry_points={

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -141,6 +141,7 @@ class VGCGLTest(TestCase):
         self.chrom_fa_nz = self._ci_input_path('small.fa')
         self._download_input('NA12877.brca1.bam_1.fq.gz')
         self.baseline = self._ci_input_path('small.vcf.gz')
+        self.bed_regions = self._ci_input_path('small_regions.bed')
 
         self._run('toil-vg', 'index', self.jobStoreLocal, self.local_outstore,
                   '--graphs', self.test_vg_graph, '--chroms', 'x',
@@ -213,6 +214,7 @@ class VGCGLTest(TestCase):
                   '--realTimeLogging', '--logInfo',
                   '--vcfeval_fasta', self.chrom_fa_nz,
                   '--vcfeval_baseline', self.baseline,
+                  '--vcfeval_bed_regions', self.bed_regions,
                   '--sample_name', '1',
                   '--calling_cores', '2',
                   '--genotype', '--genotype_opts', '-P 0', 

--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -323,8 +323,7 @@ def run_calleval_results(job, context, names, vcf_tbi_pairs, eval_results, happy
 
                 # Subset down to just the ROC tables for the names that were selected.
                 # TODO: do this in a less n^2 way.
-                subset_roc_table_ids = [roc_table_ids[i] for i in range(len(roc_table_ids)) if names[i] in subset_names]
-
+                subset_roc_table_ids = [roc_table_ids[j] for j in range(len(roc_table_ids)) if names[j] in subset_names]
                 # Append the number to the title (and output filename) for all subsets except the first
                 subset_roc_title = roc_title + ('' if subset_number == 0 else '-{}'.format(subset_number))
 

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -105,7 +105,7 @@ def validate_map_options(context, options):
     require(options.multipath or options.snarls_index is None,
             'snarls cannot be used with the single-path mapper') 
     if options.multipath:
-        require('-S' in context.config.mpmap_opts,
+        require('-S' in context.config.mpmap_opts or '--single-path-mode' in context.config.mpmap_opts,
                 '-S must be used with multipath aligner to produce GAM output')
         require(not options.bam_output,
                 '--bam_output not currently supported with multipath aligner (--multipath)')

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -210,7 +210,8 @@ def run_pipeline_index(job, context, options, inputGraphFileIDs, inputReadsFileI
     # todo: interface for gbwt
     index_job = job.addChildJobFn(run_indexing, context, inputGraphFileIDs,
                                   graph_names, options.index_name, options.chroms,
-                                  vcf_phasing_file_ids = vcf_ids, tbi_phasing_file_ids = tbi_ids,
+                                  vcf_phasing_file_ids = inputPhasingVCFFileIDs,
+                                  tbi_phasing_file_ids = inputPhasingTBIFileIDs,
                                   skip_xg=skip_xg, skip_gcsa=skip_gcsa, skip_id_ranges=skip_ranges, skip_snarls=True,
                                   make_gbwt=False,
                                   cores=context.config.misc_cores, memory=context.config.misc_mem,


### PR DESCRIPTION
As @adamnovak pointed out in https://github.com/vgteam/vg/pull/1697, the toil-vg master can't be dropped into vg's jenkins.  Main issues seem to be:
* bug in toil-vg run where vcfeval vcfs get treated as phasing vcfs in indexing (causes timeouts)
* calleval crashing out during plotting