### PR TITLE
Fix interleaved flag bugs in surject

### DIFF
--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -394,9 +394,10 @@ def run_whole_alignment(job, context, fastq, gam_input_reads, bam_input_reads, s
         bam_chrom_ids = [merge_bams_job.rv()]
 
     if surject:
+        interleaved_surject = (interleaved and (gam_input_reads or bam_input_reads)) or (fastq and len(fastq) == 2)
         zip_job = child_job.addFollowOnJobFn(run_zip_surject_input, context, gam_chunk_file_ids)
         bam_chrom_ids = [zip_job.addFollowOnJobFn(run_whole_surject, context, zip_job.rv(), sample_name + '-surject',
-                                                  interleaved, indexes.get('xg'), []).rv()]
+                                                  interleaved_surject, indexes.get('xg'), []).rv()]
 
     return gam_chrom_ids, gam_chunk_time, bam_chrom_ids
     

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -1078,7 +1078,7 @@ def run_map_eval_align(job, context, index_ids, xg_comparison_ids, gam_names, ga
                 map_times.append(map_job.rv(1))
                 out_xg_ids.append(xg_ids[i])
                 out_gam_names.append(gam_names[i] + tag_string)
-                if interleaved:
+                if condition['paired']:
                     surjected_results['pe_bam_file_ids'].append(map_job.rv(2))
                     surjected_results['pe_bam_names'].append(out_gam_names[-1] + '-surject')
                 else:


### PR DESCRIPTION
This is related to #553, but can't be sure it's a fix as I can't reproduce the error.  

Fix bugs where interleaved flag wasn't being sent to surjection because the input was pair of fastq files as opposed to the checked-for interleaved gam. 