### PR TITLE
Use GBWT instead of GPBWT for thread extraction

### DIFF
--- a/scripts/construct-hs37d5-baseline-ec2.py
+++ b/scripts/construct-hs37d5-baseline-ec2.py
@@ -18,6 +18,9 @@ def parse_args(args):
     parser.add_argument("--config", help="path of config on leader")
     parser.add_argument("--restart", action="store_true", help="resume toil workflow")
     parser.add_argument("--control", help="control sample", required=True)
+    parser.add_argument("--gcsa", help="gcsa index", action="store_true")
+    parser.add_argument("--handle_unphased", help="see same option in toil-vg construct")
+    
     args = args[1:]        
     return parser.parse_args(args)
 options = parse_args(sys.argv)
@@ -52,6 +55,11 @@ cmd = ['construct', options.job_store, options.out_store,
        '--neg_control', options.control,       
        '--alt_paths',
        '--xg_index']
+
+if options.gcsa:
+    cmd += ['--gcsa_index']
+if options.handle_unphased:
+    cmd += ['--handle_unphased', options.handle_unphased]
 
 # Note config file path is on the leader!!!!  Should fix to copy it over, but not sure how.
 cmd += ['--config', options.config] if options.config else ['--whole_genome_config']

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -134,7 +134,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.7.0-103-gf87f178b-t174-run'
+vg-docker: 'quay.io/vgteam/vg:v1.8.0-28-g7b021440-t180-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -361,7 +361,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.7.0-103-gf87f178b-t174-run'
+vg-docker: 'quay.io/vgteam/vg:v1.8.0-28-g7b021440-t180-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'


### PR DESCRIPTION
By default, use the GBWT for thread extraction when creating haplotype graphs or sample graphs.  The old logic can be reverted back to using `--gpbwt_threads`.  Resolves #500.

This requires https://github.com/vgteam/vg/pull/1720 to actually work. For whole genome sample graphs, https://github.com/vgteam/vg/pull/1718 is also going to be necessary.

Also changed the `--sample_graph_unphased` option into `--handle_unphased` which applies to haplotype graphs in addition to sample graphs 

