### PR TITLE
arbitrarily phase unphased variants by default for haplo/sample grpah

### DIFF
--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -87,7 +87,7 @@ def construct_subparser(parser):
                         help="Create a graph including only variants with given minium allele frequency."
                         " If multiple frequencies given, a graph will be made for each one")
 
-    parser.add_argument("--handle_unphased", default='skip',
+    parser.add_argument("--handle_unphased", default='arbitrary',
                         choices=['skip', 'keep', 'arbitrary'],
                         help='How to handle unphased variants in the VCF when creating the sample or haplo graph. \"skip\": '
                         'ignore variants, just using the reference allele. \"keep\": keep the unphased variants, '


### PR DESCRIPTION
I think this probably makes more sense for our use cases of sample graphs for controls and thread graphs to simulate from.  At least more sense than dropping variants by default. 