### PR TITLE
specify gamsort threads; use existing gais

### DIFF
--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -548,7 +548,8 @@ def run_calling(job, context, xg_file_id, alignment_file_id, path_names, vcf_off
     gam_index_path = gam_sort_path + '.gai'
     
     with open(gam_sort_path, "w") as gam_sort_stream:
-        gamsort_cmd = ['vg', 'gamsort', '-i', os.path.basename(gam_index_path), os.path.basename(gam_path)]
+        gamsort_cmd = ['vg', 'gamsort', '-i', os.path.basename(gam_index_path), os.path.basename(gam_path),
+                       '--threads', str(context.config.gam_index_cores)]
         timer = TimeTracker('call-gam-index')
         context.runner.call(job, gamsort_cmd, work_dir=work_dir, outfile=gam_sort_stream)
         timer.stop()

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -289,7 +289,7 @@ def run_pipeline_call(job, context, options, xg_file_id, id_ranges_file_id, chr_
         chroms = options.chroms
     assert len(chr_gam_ids) == len(chroms)
 
-    call_job = job.addChildJobFn(run_all_calling, context, xg_file_id, chr_gam_ids, chroms,
+    call_job = job.addChildJobFn(run_all_calling, context, xg_file_id, chr_gam_ids, None, chroms,
                                  options.vcf_offsets, options.sample_name,
                                  options.genotype, not options.no_augment,
                                  cores=context.config.misc_cores, memory=context.config.misc_mem,


### PR DESCRIPTION
One advantage of the .gai over the Rocksdb is that it's easier to pass into the file store because it's not a directory.  So if a .gai is present, use it for calling when possible (as is done for .bai in calleval presently)