### PR TITLE
Reference and read generation improvements

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -134,7 +134,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-123-gd4adc2fd-t217-run'
+vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-188-g1f7807ea-t219-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -370,7 +370,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-123-gd4adc2fd-t217-run'
+vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-188-g1f7807ea-t219-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -114,8 +114,6 @@ def validate_construct_options(options):
             '--regions required with --haplo_sample')
     require(not (options.haplo_sample and options.merge_graphs),
             '--merge_graphs not currently supported with --haplo_sample')
-    require(not (options.haplo_sample and options.fasta_regions),
-            '--fasta_regions not currently supported with --haplo_sample')    
     require(not options.vcf or len(options.vcf) == 1 or not options.regions or
             len(options.vcf) <= len(options.regions),
             'if many vcfs specified, cannot have more vcfs than --regions')

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -110,8 +110,8 @@ def validate_construct_options(options):
     """
     Throw an error if an invalid combination of options has been selected.
     """
-    require(not options.haplo_sample or options.regions,
-            '--regions required with --haplo_sample')
+    require(not options.haplo_sample or (options.regions or options.fasta_regions),
+            '--regions or --fasta_regions required with --haplo_sample')
     require(not (options.haplo_sample and options.merge_graphs),
             '--merge_graphs not currently supported with --haplo_sample')
     require(not options.vcf or len(options.vcf) == 1 or not options.regions or
@@ -127,8 +127,8 @@ def validate_construct_options(options):
     # in parallel, but the indexing code always indexes them together.
     require(not options.gbwt_index or len(options.vcf) >= 1,
             '--gbwt_index requires --vcf')
-    require(not options.sample_graph or options.regions,
-            '--regions required with --sample_graph')
+    require(not options.sample_graph or (options.regions or options.fasta_regions),
+            '--regions or --fasta_regions required with --sample_graph')
     require(options.primary or options.pangenome or options.pos_control or options.neg_control or
             options.sample_graph or options.haplo_sample or options.filter_ceph or options.filter_samples or
             options.min_af,

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -936,6 +936,9 @@ def run_make_haplo_thread_graphs(job, context, vg_id, vg_name, output_name, chro
         assert(sample is not None)
 
         try:
+            # Work out a tag for this graph, depending on whether it belongs to one chromosome or not
+            tag = '_{}'.format(chroms[0]) if len(chroms) == 1 else ''
+        
             if thread_count == 0:
                 # We have no haplotype data on this contig. This is something
                 # like chrM, and we want to pass through the ref version.
@@ -943,7 +946,6 @@ def run_make_haplo_thread_graphs(job, context, vg_id, vg_name, output_name, chro
             else:
                 # We know we have haplotype data on this contig.
                 # Pull out the graph with just the haplotype thread as the only path to vg_with_thread_as_path_path
-                tag = '_{}'.format(chroms[0]) if len(chroms) == 1 else ''
                 vg_with_thread_as_path_path = os.path.join(work_dir, '{}{}_thread_{}_merge.vg'.format(output_name, tag, hap))
                 logger.info('Creating thread graph {}'.format(vg_with_thread_as_path_path))
                 with open(vg_with_thread_as_path_path, 'w') as thread_only_file:

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -1035,9 +1035,9 @@ def run_make_sample_region_graph(job, context, vg_id, vg_name, output_name, chro
     # Check if there are any threads in the index
     # TODO: This requires the GBWT, so we probably should remove the gPBWT support which nobody needs anymore.
     assert(gbwt_id)
-    path_count = int(context.runner.call(
+    path_count = int(context.runner.call(job,
         [['vg', 'paths', '--threads', '--list', '--gbwt', os.path.basename(gbwt_path), '-x',  os.path.basename(xg_path)], 
-        ['wc', '-l']], check_output=True))
+        ['wc', '-l']], work_dir = work_dir, check_output = True))
     if path_count == 0:
         # There are no threads in our GBWT index (it is empty).
         # This means that we have no haplotype data for this graph.

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -763,9 +763,11 @@ def run_indexing(job, context, inputGraphFileIDs,
     'chrom_gbwt', 'chrom_thread', 'id_ranges', or 'snarls') to index file ID(s)
     if created.
     
-    For 'chrom_xg', 'chrom_gbwt' and 'chrom_thread', the value is a list of one
-    XG or GBWT or thread DB per chromosome in chroms, to support `vg prune`.
-    The others are all single file IDs
+    For 'chrom_xg' and 'chrom_gbwt' the value is a list of one XG or GBWT or
+    thread DB per chromosome in chroms, to support `vg prune`. For
+    'chrom_thread', we have a value per chromosome that actually has any
+    threads (instead of padding out with Nones). The others are all single file
+    IDs.
     
     """
     child_job = Job()

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -864,7 +864,10 @@ def run_indexing(job, context, inputGraphFileIDs,
                                                                      preemptable=not make_gbwt or context.config.gbwt_index_preemptable)
                 indexes['chrom_xg'].append(xg_chrom_index_job.rv(0))
                 indexes['chrom_gbwt'].append(xg_chrom_index_job.rv(1))
-                if separate_threads:
+                if separate_threads and vcf_id is not None:
+                    # We had a phasing VCF, and we want to pass along the
+                    # threads we got from it because the final xg needs to know
+                    # about them.
                     indexes['chrom_thread'].append(xg_chrom_index_job.rv(2))
 
             if len(chroms) > 1 and vcf_phasing_file_ids and make_gbwt:

--- a/src/toil_vg/vg_sim.py
+++ b/src/toil_vg/vg_sim.py
@@ -393,14 +393,15 @@ def sim_main(context, options):
                                      options.seed, options.sim_chunks,
                                      inputXGFileIDs,
                                      inputAnnotXGFileID,
-                                     tagBEDIDs,
-                                     options.path,
-                                     inputFastqFileID,
-                                     options.out_name,
+                                     tag_bed_ids = tagBEDIDs,
+                                     paths = options.path,
+                                     drop_contigs_matching = options.drop_contigs_matching,
+                                     fastq_id = inputFastqFileID,
+                                     out_name = options.out_name,
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)
-
+                                     
             init_job.addFollowOn(root_job)            
             
             # Run the job and store the returned list of output files to download


### PR DESCRIPTION
This PR contains changes I need in order to generate haplo reference graphs, haplotype threads, and reads with the relatively more complex reference structure I want to use for GRCh38.

Basically, we can now have sequences in the reference that don't have VCFs associated with them (i.e. chrM, the chrUn contigs, and the decoys), and have them show up in the haplotype graphs anyway. We can also filter out reads from contigs matching regexes (like the decoys, or chrY for XX samples) when generating simulated reads.

Corresponding changes to let the genotyper know not to try and genotype these regions have not yet been made.

Also, I ripped out some of the gPBWT support, since the GBWT is mature enough now to just use that.

This fixes #606, and it should close #607 as wontfix, because instead of taking the contig names from a file we can now pull them out of the FASTA in more circumstances, as long as you have ordered your FASTA contigs correctly to correspond to your input VCFs, with any VCF-less sequences following after.