### PR TITLE
Allow pre-generating BWA indexes

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -77,6 +77,11 @@ snarl-index-cores: 1
 snarl-index-mem: '4G'
 snarl-index-disk: '2G'
 
+# Resources for BWA indexing.
+bwa-index-cores: 1
+bwa-index-mem: '4G'
+bwa-index-disk: '2G'
+
 # Resources for fastq splitting and gam merging
 # Important to assign as many cores as possible here for large fastq inputs
 fq-split-cores: 1
@@ -312,6 +317,11 @@ gcsa-index-preemptable: 'False'
 snarl-index-cores: 1
 snarl-index-mem: '200G'
 snarl-index-disk: '100G'
+
+# Resources for BWA indexing.
+bwa-index-cores: 1
+bwa-index-mem: '40G'
+bwa-index-disk: '40G'
 
 # Resources for fastq splitting and gam merging
 # Important to assign as many cores as possible here for large fastq inputs

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -792,11 +792,11 @@ def run_merge_gbwts(job, context, chrom_gbwt_ids, index_name):
 
         return context.write_output_file(job, os.path.join(work_dir, index_name + '.gbwt'))
         
-def run_bwa_index(job, context, fasta_file_id, bwa_index_ids=None, intermediate=False):
+def run_bwa_index(job, context, fasta_file_id, bwa_index_ids=None, intermediate=False, copy_fasta=False):
     """
     Make a bwa index for a fast sequence if not given in input.
     
-    If intermediate is set to true, do not output them. Otherwise, output them
+    If intermediate is set to True, do not output them. Otherwise, output them
     as bwa.fa.<index type>.
     
     Returns a dict from index extension to index file ID.
@@ -805,6 +805,9 @@ def run_bwa_index(job, context, fasta_file_id, bwa_index_ids=None, intermediate=
     
     If such a nonempty dict is passed in already, return that instead (and
     don't output any files).
+    
+    If copy_fasta is True (and intermediate is False), also output the input FASTA to the out store.
+    
     """
     if not bwa_index_ids:
         bwa_index_ids = dict()
@@ -822,6 +825,10 @@ def run_bwa_index(job, context, fasta_file_id, bwa_index_ids=None, intermediate=
         for idx_file in glob.glob('{}.*'.format(fasta_file)):
             # Upload all the index files created, and store their IDs under their extensions
             bwa_index_ids[idx_file[len(fasta_file):]] = write_file(job, idx_file)
+            
+        if copy_fasta and not intermediate:
+            # We ought to upload the FASTA also.
+            context.write_output_file(job, fasta_file)
 
     return bwa_index_ids
         

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -32,7 +32,7 @@ def index_subparser(parser):
     # Add the Toil options so the job store is the first argument
     Job.Runner.addToilOptions(parser)
     
-    # General options
+    # Options specific to the toil-vg index driver
     parser.add_argument("out_store",
         help="output store.  All output written here. Path specified using same syntax as toil jobStore")
 
@@ -40,12 +40,15 @@ def index_subparser(parser):
                         help="input graph(s). one per chromosome (separated by space)")
 
     parser.add_argument("--chroms", nargs='+',
-                        help="Name(s) of reference path in graph(s) (separated by space).  If --graphs "
+                        help="name(s) of reference path in graph(s) (separated by space).  If --graphs "
                         " has multiple elements, must be same length/order as --chroms (not needed for xg_index)")
 
     parser.add_argument("--node_mapping", type=make_url,
-                        help="node mapping file required for gbwt pruning.  created by toil-vg construct"
+                        help="node mapping file required for gbwt pruning. Created by toil-vg construct"
                         " (or vg ids -j)")
+                        
+    parser.add_argument("--bwa_index_fasta", type=make_url,
+                        help="index the given FASTA for BWA MEM alignment")
 
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)
@@ -58,7 +61,12 @@ def index_subparser(parser):
     add_container_tool_parse_args(parser)
 
 def index_toggle_parse_args(parser):
-    """ common args we do not want to share with toil-vg run """
+    """
+    Common args we do not want to share with toil-vg run, and which toggle
+    different index types on and off.
+    
+    Safe to use in toil-vg construct without having to import any files.
+    """
     parser.add_argument("--gcsa_index", action="store_true",
                         help="Make a gcsa index for each output graph")
     parser.add_argument("--xg_index", action="store_true",
@@ -71,11 +79,11 @@ def index_toggle_parse_args(parser):
                         help="Make chromosome id ranges tables (so toil-vg map can optionally split output by chromosome)")
     parser.add_argument("--all_index", action="store_true",
                         help="Equivalent to --gcsa_index --xg_index --gbwt_index --snarls_index --id_ranges_index")
-    parser.add_argument("--bwa_index_fasta", type=make_url,
-                        help="index the given FASTA for BWA MEM alignment")
     
 def index_parse_args(parser):
-    """ centralize indexing parameters here """
+    """
+    Indexing parameters which can be part of the main toil-vg run pipeline.
+    """
     
     parser.add_argument("--gcsa_index_cores", type=int,
         help="number of threads during the gcsa indexing step")

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -1218,7 +1218,8 @@ def run_map_eval_align(job, context, index_ids, xg_comparison_ids, gam_names, ga
                 bwa_start_job = Job()
                 job.addChild(bwa_start_job)
                 bwa_index_job = bwa_start_job.addChildJobFn(run_bwa_index, context,
-                                                            fasta_file_id, bwa_index_ids=bwa_index_ids,
+                                                            fasta_file_id,
+                                                            bwa_index_ids=bwa_index_ids,
                                                             intermediate=True,
                                                             cores=context.config.bwa_index_cores, memory=context.config.bwa_index_mem,
                                                             disk=context.config.bwa_index_disk)

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -36,7 +36,7 @@ from toil_vg.vg_common import require, make_url, remove_ext,\
     add_common_vg_parse_args, add_container_tool_parse_args, get_vg_script, run_concat_lists, \
     parse_plot_sets, title_to_filename
 from toil_vg.vg_map import map_parse_args, run_split_reads_if_needed, run_mapping
-from toil_vg.vg_index import run_indexing
+from toil_vg.vg_index import run_indexing, run_bwa_index
 from toil_vg.context import Context, run_write_info_to_outstore
 
 logger = logging.getLogger(__name__)
@@ -261,27 +261,6 @@ def parse_int(value):
     """
     
     return int(value) if value.strip() != '' else 0
-
-def run_bwa_index(job, context, fasta_file_id, bwa_index_ids):
-    """
-    Make a bwa index for a fast sequence if not given in input. then run bwa mem
-    
-    Retuns a pair of BAM IDs, one for unpaired and one for paired. Either will be None if the corresponding flag is false.
-    """
-    if not bwa_index_ids:
-        bwa_index_ids = dict()
-        work_dir = job.fileStore.getLocalTempDir()
-        # Download the FASTA file to be indexed
-        # It would be nice to name it the same as the actual input FASTA but we'd have to peek at the options
-        fasta_file = os.path.join(work_dir, 'toindex.fa')
-        job.fileStore.readGlobalFile(fasta_file_id, fasta_file)
-        cmd = ['bwa', 'index', os.path.basename(fasta_file)]
-        context.runner.call(job, cmd, work_dir = work_dir)
-        for idx_file in glob.glob('{}.*'.format(fasta_file)):
-            # Upload all the index files created, and store their IDs under their extensions
-            bwa_index_ids[idx_file[len(fasta_file):]] = context.write_intermediate_file(job, idx_file)
-
-    return bwa_index_ids
 
 def run_bam_to_fastq(job, context, bam_file_id, paired_mode, add_paired_suffix=False):
     """
@@ -1239,9 +1218,10 @@ def run_map_eval_align(job, context, index_ids, xg_comparison_ids, gam_names, ga
                 bwa_start_job = Job()
                 job.addChild(bwa_start_job)
                 bwa_index_job = bwa_start_job.addChildJobFn(run_bwa_index, context,
-                                                            fasta_file_id, bwa_index_ids,
-                                                            cores=context.config.alignment_cores, memory=context.config.alignment_mem,
-                                                            disk=context.config.alignment_disk)
+                                                            fasta_file_id, bwa_index_ids=bwa_index_ids,
+                                                            intermediate=True,
+                                                            cores=context.config.bwa_index_cores, memory=context.config.bwa_index_mem,
+                                                            disk=context.config.bwa_index_disk)
                 bwa_index_ids = bwa_index_job.rv()
                     
             if condition["paired"]:
@@ -1293,7 +1273,7 @@ def run_map_eval_comparison(job, context, xg_file_ids, gam_names, gam_file_ids,
     
     """
     
-    # munge out the returned pair from run_bwa_index()
+    # munge out the returned pair of BAMs
     if bwa_bam_file_ids[0] is not None:
         bam_file_ids.append(bwa_bam_file_ids[0])
         bam_names.append('bwa-mem')


### PR DESCRIPTION
This ought to fix #616.

It would be somewhat nicer to maybe expose this in construct too, but construct won't always have a single FASTA, and also the way I use it the FASTA it gets might not be the FASTA you want to use for BWA (since you may trim contigs down with region specifiers).

Maybe the right solution there is to eventually have construct be able to spit out a FASTA and BWA index corresponding to the regions it made graphs from.