### PR TITLE
Fix a crash and prepare for a real release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Installation requires Python and Toil.  We recommend installing within virtualen
 
     virtualenv toilvenv
     source toilvenv/bin/activate
-    pip install toil[aws,mesos]==3.16.0
-    pip install --pre toil-vg
+    pip install toil[aws,mesos]==3.18.0
+    pip install toil-vg
     
 ## WIKI
 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -492,7 +492,11 @@ class VGCGLTest(TestCase):
 
     def test_09_sim_small_genotype_no_augment(self):
         ''' 
-        This is the same as test #1, but exercises --force_outstore and --genotype with no augment
+        This is the same as test #1, but exercises --force_outstore and
+        --genotype with --no_augment.
+         
+        TODO: --no_augment is ignored for genotype because we use genotype's
+        built-in augment.
         '''
         self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
         self.test_vg_graph = self._ci_input_path('small.vg')

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -105,11 +105,7 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
                 keep_pileup = False, keep_xg = False, keep_gam = False,
                 keep_augmented = False, chunk_name = 'call', genotype = False,
                 augment = True, recall = False):
-    """ Run vg call on a single graph.
-
-    NOTE: Can now run vg genotype as well, but the plan is to fold genotype into call
-    soon.  At that point, will remove run_vg_genotype() function entirely, which is kinda
-    sitting around useless now. 
+    """ Run vg call or vg genotype on a single graph.
 
     Returns (vcf_id, pileup_id, xg_id, gam_id, augmented_graph_id).  pileup_id and xg_id
     can be same as input if they are not computed.  If pileup/xg/augmented are 
@@ -122,6 +118,10 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
     gam filtering is only done if filter_opts are passed in. 
 
     chunk_name option is only for working filenames (to make more readable)
+    
+    When runnign vg genotype, we can't not augment, and we can't recall (since
+    recall in vg genotype needs a VCF). We also won't return a pileup even if
+    asked to do so, because we don't compute one.
 
     """
 
@@ -136,11 +136,14 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
     defray = filter_opts and ('-D' in filter_opts or '--defray-ends' in filter_opts)
     if xg_id and defray:
         job.fileStore.readGlobalFile(xg_id, xg_path)
+        
+    # Define paths for all the files we might make
     pu_path = os.path.join(work_dir, '{}.pu'.format(chunk_name))
     trans_path = os.path.join(work_dir, '{}.trans'.format(chunk_name))
     support_path = os.path.join(work_dir, '{}.support'.format(chunk_name))
     aug_path = os.path.join(work_dir, '{}_aug.vg'.format(chunk_name))
     aug_gam_path = os.path.join(work_dir, '{}_aug.gam'.format(chunk_name))
+    vcf_path = os.path.join(work_dir, '{}_call.vcf'.format(chunk_name))
 
     timer = TimeTracker()
 
@@ -162,7 +165,7 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
         if defray:
             filter_command += ['-x', os.path.basename(xg_path)]
 
-    # we filter separated when running genotype (due to augment -A)
+    # we filter separately when running genotype
     if filter_command and genotype:
         with open(gam_filter_path, 'w') as gam_filter_stream:
             timer.start('call-filter')
@@ -171,16 +174,68 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
         gam_path = gam_filter_path
         filter_command = None
         
-    # augment command with optional filter piped at beginning
-    augment_generated_opts = ['-Z', os.path.basename(trans_path)]
-    if keep_pileup:
-        augment_generated_opts += ['-P', os.path.basename(pu_path)]
     if genotype:
-        # Make sure to use the augmentation mode that we need for genotype (augment with everything but no supports)
-        augment_generated_opts += ['-a', 'direct']
-        # We need to keep the augmented gam
-        augment_generated_opts += ['-A', os.path.basename(aug_gam_path)]
+        # When using vg genotype, we use genotype's built-in augmentation and
+        # facility for dumping the augmented graph.
+        
+        # Filtering already happened.
+        # We can't do recall (no passed VCF) and we can't skip augmentation.
+        assert(augment)
+        assert(not recall)
+        
+        # How do we actually genotype
+        command = ['vg', 'genotype', os.path.basename(vg_path), '-t',
+                   str(context.config.calling_cores), '-s', sample_name,
+                   '-v', '-E', '-G', os.path.basename(gam_path)]
+                   
+        if keep_augmented:
+            # Remember to dump the augmented graph so we can keep it
+            command += ['-a', aug_path]
+        
+        if call_opts:
+            command += call_opts
+        for path_name in path_names:
+            command += ['-r', path_name]
+        for seq_name in seq_names:
+            command += ['-c', seq_name]
+        for seq_length in seq_lengths:
+            command += ['-l', seq_length]
+        for seq_offset in seq_offsets:
+            command += ['-o', seq_offset]
+        
+        try:
+            with open(vcf_path, 'w') as vggenotype_stdout:
+            
+                timer.start('genotype')
+                context.runner.call(job, command, work_dir=work_dir,
+                                     outfile=vggenotype_stdout)
+                timer.stop()
+                
+            vcf_id = context.write_intermediate_file(job, vcf_path)
+
+        except Exception as e:
+            logging.error("Genotyping failed. Dumping files.")
+            for dump_path in [vg_path, gam_path, gam_filter_path, aug_path]:
+                if dump_path and os.path.isfile(dump_path):
+                    context.write_output_file(job, dump_path)        
+            raise e
+        
+        
+        gam_id, pileup_id, aug_graph_id = None, None, None
+        if keep_gam and filter_opts:
+            gam_id = context.write_intermediate_file(job, gam_filter_path)
+        # We can't keep the pileup because there isn't one.
+        if keep_augmented:
+            aug_graph_id = context.write_intermediate_file(job, aug_path)
+        
     else:
+        # When using vg call, we use a separate vg augment step and then run vg call
+        
+        # augment command with optional filter piped at beginning
+        augment_generated_opts = ['-Z', os.path.basename(trans_path)]
+        if keep_pileup:
+            augment_generated_opts += ['-P', os.path.basename(pu_path)]
+            
         # Make sure to use the augmentation mode for vg call (which can calculate supports)
         augment_generated_opts += ['-a', 'pileup']
         # And calculate the supports instead of the augmented gam
@@ -194,51 +249,45 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
                     del augment_opts[i]
                     del augment_opts[i]
             augment_generated_opts += ['--min-aug-support', '9999999']
-            
-    augment_command = []
-    if filter_command is not None:
-        aug_gam_input = '-'
-        augment_command.append(filter_command)
-        if keep_gam:
-            augment_command.append(['tee', os.path.basename(gam_filter_path)])
-    else:
-        aug_gam_input = os.path.basename(gam_path)
-    augment_command.append(['vg', 'augment', os.path.basename(vg_path), aug_gam_input,
-                    '-t', str(context.config.calling_cores)] + augment_opts + augment_generated_opts)
-
-    vcf_path = os.path.join(work_dir, '{}_call.vcf'.format(chunk_name))
-
-    # call
-    try:
-        if augment:
-            with open(aug_path, 'w') as aug_stream:
-                timer.start('call-filter-augment')
-                context.runner.call(job, augment_command, work_dir=work_dir, outfile=aug_stream)
-                timer.stop()
+                
+        augment_command = []
+        if filter_command is not None:
+            aug_gam_input = '-'
+            augment_command.append(filter_command)
+            if keep_gam:
+                augment_command.append(['tee', os.path.basename(gam_filter_path)])
         else:
-            # hack to skip augmentation
-            aug_path = vg_path
-            aug_gam_path = gam_path
-            
-        gam_id, pileup_id, aug_graph_id = None, None, None
-        if keep_gam and filter_opts:
-            gam_id = context.write_intermediate_file(job, gam_filter_path)
-        if keep_pileup:
-            pileup_id = context.write_intermediate_file(job, pu_path)
-        if keep_augmented:
-            aug_graph_id = context.write_intermediate_file(job, aug_path)
-        
-        with open(vcf_path, 'w') as vgcall_stdout:
-            if not genotype:
-                command = ['vg', 'call', os.path.basename(aug_path), '-t',
-                           str(context.config.calling_cores), '-S', sample_name,
-                           '-z', os.path.basename(trans_path),
-                           '-s', os.path.basename(support_path),
-                           '-b', os.path.basename(vg_path)]
+            aug_gam_input = os.path.basename(gam_path)
+        augment_command.append(['vg', 'augment', os.path.basename(vg_path), aug_gam_input,
+                        '-t', str(context.config.calling_cores)] + augment_opts + augment_generated_opts)
+
+        # call
+        try:
+            if augment:
+                with open(aug_path, 'w') as aug_stream:
+                    timer.start('call-filter-augment')
+                    context.runner.call(job, augment_command, work_dir=work_dir, outfile=aug_stream)
+                    timer.stop()
             else:
-                command = ['vg', 'genotype', os.path.basename(aug_path), '-t',
-                           str(context.config.calling_cores), '-s', sample_name,
-                           '-v', '-E', '-G', os.path.basename(aug_gam_path)]
+                # hack to skip augmentation
+                aug_path = vg_path
+                aug_gam_path = gam_path
+                
+            gam_id, pileup_id, aug_graph_id = None, None, None
+            if keep_gam and filter_opts:
+                gam_id = context.write_intermediate_file(job, gam_filter_path)
+            if keep_pileup:
+                pileup_id = context.write_intermediate_file(job, pu_path)
+            if keep_augmented:
+                aug_graph_id = context.write_intermediate_file(job, aug_path)
+            
+            
+            command = ['vg', 'call', os.path.basename(aug_path), '-t',
+                       str(context.config.calling_cores), '-S', sample_name,
+                       '-z', os.path.basename(trans_path),
+                       '-s', os.path.basename(support_path),
+                       '-b', os.path.basename(vg_path)]
+                
             if call_opts:
                 command += call_opts
             for path_name in path_names:
@@ -250,20 +299,21 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
             for seq_offset in seq_offsets:
                 command += ['-o', seq_offset]
 
-            timer.start('genotype' if genotype else 'call')
-            context.runner.call(job, command, work_dir=work_dir,
-                                 outfile=vgcall_stdout)
-            timer.stop()            
+            with open(vcf_path, 'w') as vgcall_stdout:
+                timer.start('call')
+                context.runner.call(job, command, work_dir=work_dir,
+                                     outfile=vgcall_stdout)
+                timer.stop()            
 
-        vcf_id = context.write_intermediate_file(job, vcf_path)
+            vcf_id = context.write_intermediate_file(job, vcf_path)
 
-    except Exception as e:
-        logging.error("Calling failed. Dumping files.")
-        for dump_path in [vg_path, pu_path, gam_filter_path,
-                          aug_path, support_path, trans_path, aug_gam_path]:
-            if dump_path and os.path.isfile(dump_path):
-                context.write_output_file(job, dump_path)        
-        raise e
+        except Exception as e:
+            logging.error("Calling failed. Dumping files.")
+            for dump_path in [vg_path, pu_path, gam_filter_path,
+                              aug_path, support_path, trans_path, aug_gam_path]:
+                if dump_path and os.path.isfile(dump_path):
+                    context.write_output_file(job, dump_path)        
+            raise e
         
     return vcf_id, pileup_id, xg_id, gam_id, aug_graph_id, timer
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -139,7 +139,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-188-g1f7807ea-t219-run'
+vg-docker: 'quay.io/vgteam/vg:v1.11.0-0-gea4aaded-t241-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'
@@ -380,7 +380,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:dev-v1.9.0-188-g1f7807ea-t219-run'
+vg-docker: 'quay.io/vgteam/vg:v1.11.0-0-gea4aaded-t241-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'vandhanak/bcftools:1.3.1'

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -112,8 +112,8 @@ def validate_construct_options(options):
     """
     Throw an error if an invalid combination of options has been selected.
     """
-    require(not options.haplo_sample or (options.regions or options.fasta_regions),
-            '--regions or --fasta_regions required with --haplo_sample')
+    require(options.regions or options.fasta_regions,
+            '--regions or --fasta_regions required')
     require(options.vcf == [] or len(options.vcf) == 1 or not options.regions or
             len(options.vcf) <= len(options.regions),
             'if many vcfs specified, cannot have more vcfs than --regions')

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -347,7 +347,7 @@ def main():
     7 = Download output files from remote output fileStore to local output directory
     ================================================================================
     """
-
+    
     args = parse_args(sys.argv[1:])
     
     # Write out our config file that's necessary for all other subcommands

--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '1.4.1a1'
+version = '1.4.1'
 
 required_versions = {'pyyaml': '>=3.11',
                      'tsv': '==1.2',


### PR DESCRIPTION
If you didn't specify --regions or --fasta_regions to toil-vg construct, you could get it to crash. This fixes that.

I'm also updating the vg version to the most revent vg release, and telling users to install the current Toil (1.18) and the current toil-vg (no --pre). I'm also upping the version in the repo to 1.4.1 proper; I'm going to cut a release (or make @cmarkello do it) after this goes in. We've seen some user confusion caused by the current release version (1.2) being way too out of date to work on current toil.