### PR TITLE
move to 1.5.0 prerelease

### DIFF
--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '1.4.1'
+version = '1.5.0a1'
 
 required_versions = {'pyyaml': '>=3.11',
                      'tsv': '==1.2',


### PR DESCRIPTION
Otherwise, version 1.4.1 will get clobbered in pypi whenever we merge into master.  Putting a 1.5.0 release on pypi can then be done by dropping the a1 (then subsequently moving to 1.5.1a1...)

On a related note, is there a benefit to spamming pypi with millions of dev versions?  This is from code which I guess is copied from Toil:

https://github.com/vgteam/toil-vg/blob/master/Makefile#L92

I'm tempted to knock BUILD_NUMBER out of here to only have one prerelease for any given release...