### PR TITLE
Fix --recall option to better handle sequencing errors in SV insertions

### DIFF
--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -101,7 +101,7 @@ def sort_vcf(job, drunner, vcf_path, sorted_vcf_path):
 
 def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
                 path_names = [], seq_names = [], seq_offsets = [], seq_lengths = [],
-                filter_opts = [], augment_opts = [], call_opts = [],
+                filter_opts = [], augment_opts = [], call_opts = [], recall_opts = [],
                 keep_pileup = False, keep_xg = False, keep_gam = False,
                 keep_augmented = False, chunk_name = 'call', genotype = False,
                 augment = True, recall = False):
@@ -289,7 +289,9 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
                        '-s', os.path.basename(support_path),
                        '-b', os.path.basename(vg_path)]
                 
-            if call_opts:
+            if recall and recall_opts:
+                command += recall_opts
+            elif call_opts:
                 command += call_opts
             for path_name in path_names:
                 command += ['-r', path_name]
@@ -453,6 +455,7 @@ def run_call_chunk(job, context, path_name, chunk_i, num_chunks, chunk_offset, c
         filter_opts = context.config.filter_opts,
         augment_opts = context.config.augment_opts,
         call_opts = context.config.call_opts if not genotype else context.config.genotype_opts,
+        recall_opts = context.config.recall_opts if not genotype else [],
         chunk_name = 'chunk_{}_{}'.format(path_name, chunk_offset),
         genotype = genotype,
         augment = augment,

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -236,6 +236,9 @@ augment-opts: ['-q', '10']
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: []
 
+# Options to pass to vg call when using --recall. (do not include file/contig/sample names or -t/--threads)
+recall-opts: ['-u', '-n', '0']
+
 # Options to pass to vg genotype. (do not include file/contig/sample names or -t/--threads)
 genotype-opts: []
 
@@ -478,6 +481,9 @@ augment-opts: ['-q', '10']
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: []
 
+# Options to pass to vg call when using --recall. (do not include file/contig/sample names or -t/--threads)
+recall-opts: ['-u', '-n', '0']
+
 # Options to pass to vg genotype. (do not include file/contig/sample names or -t/--threads)
 genotype-opts: []
 
@@ -519,7 +525,7 @@ def apply_config_file_args(args):
     """
 
     # turn --*_opts from strings to lists to be consistent with config file
-    for x_opts in ['map_opts', 'call_opts', 'filter_opts', 'genotype_opts', 'vcfeval_opts', 'sim_opts',
+    for x_opts in ['map_opts', 'call_opts', 'recall_opts', 'filter_opts', 'genotype_opts', 'vcfeval_opts', 'sim_opts',
                    'bwa_opts', 'gcsa_opts', 'mpmap_opts', 'augment_opts', 'prune_opts']:
         if x_opts in args.__dict__.keys() and type(args.__dict__[x_opts]) is str:
             args.__dict__[x_opts] = make_opts_list(args.__dict__[x_opts])


### PR DESCRIPTION
Will require a vg this patch: https://github.com/vgteam/vg/pull/1978/commits/885f6bf5e1951d96c3dd84b134d5cc42042f2157 to be effective.

There's probably more work to be done here (precision issues) but it's a start...