### PR TITLE
Improve sveval

### DIFF
--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -584,7 +584,7 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                     if sveval:
                         sveval_results[bam_caller_out_name]["clipped"] = \
                         bam_caller_job.addFollowOnJobFn(run_sv_eval, context, sample_name, bam_caller_vcf_tbi_id_pair,
-                                                        truth_vcf_id, truth_vcf_tbi_id, min_sv_len=25,
+                                                        truth_vcf_id, truth_vcf_tbi_id, min_sv_len=20,
                                                         sv_overlap=0.5, sv_region_overlap=1,
                                                         bed_id=bed_id,
                                                         out_name=bam_caller_out_name,

--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -464,7 +464,8 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                  vcfeval_baseline_id, vcfeval_baseline_tbi_id, caller_fasta_id, vcfeval_fasta_id,
                  bed_id, clip_only, call, genotype, sample_name, chroms, vcf_offsets,
                  vcfeval_score_field, plot_sets, filter_opts_gt, surject, interleaved,
-                 freebayes, platypus, happy, sveval, recall):
+                 freebayes, platypus, happy, sveval, recall, min_sv_len, max_sv_len, sv_overlap,
+                 sv_region_overlap, sv_smooth):
     """
     top-level call-eval function. Runs the caller and genotype on every
     gam, and freebayes on every bam. The resulting vcfs are put through
@@ -584,8 +585,12 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                     if sveval:
                         sveval_results[bam_caller_out_name]["clipped"] = \
                         bam_caller_job.addFollowOnJobFn(run_sv_eval, context, sample_name, bam_caller_vcf_tbi_id_pair,
-                                                        truth_vcf_id, truth_vcf_tbi_id, min_sv_len=20,
-                                                        sv_overlap=0.5, sv_region_overlap=1,
+                                                        truth_vcf_id, truth_vcf_tbi_id,
+                                                        min_sv_len=min_sv_len,
+                                                        max_sv_len=max_sv_len,
+                                                        sv_overlap=sv_overlap,
+                                                        sv_region_overlap=sv_region_overlap,
+                                                        sv_smooth=sv_smooth,
                                                         bed_id=bed_id,
                                                         out_name=bam_caller_out_name,
                                                         cores=context.config.vcfeval_cores,
@@ -616,8 +621,13 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                     if sveval:
                         sveval_results[bam_caller_out_name]["unclipped"] = \
                         bam_caller_job.addFollowOnJobFn(run_sv_eval, context, sample_name, bam_caller_vcf_tbi_id_pair,
-                                                        truth_vcf_id, truth_vcf_tbi_id, min_sv_len=25,
-                                                        sv_overlap=0.5, sv_region_overlap=1, bed_id=None,
+                                                        truth_vcf_id, truth_vcf_tbi_id,
+                                                        min_sv_len=min_sv_len,
+                                                        max_sv_len=max_sv_len,
+                                                        sv_overlap=sv_overlap,
+                                                        sv_region_overlap=sv_region_overlap,
+                                                        sv_smooth=sv_smooth,
+                                                        bed_id=None,
                                                         out_name=bam_caller_out_name if not bed_id else bam_caller_out_name + '-unclipped',                                                        
                                                         cores=context.config.vcfeval_cores,
                                                         memory=context.config.vcfeval_mem,
@@ -671,8 +681,12 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                         if sveval:
                             sveval_results[out_name]["clipped"] = \
                             call_job.addFollowOnJobFn(run_sv_eval, context, sample_name, vcf_tbi_id_pair,
-                                                      truth_vcf_id, truth_vcf_tbi_id, min_sv_len=25,
-                                                      sv_overlap=0.5, sv_region_overlap=1,
+                                                      truth_vcf_id, truth_vcf_tbi_id,
+                                                      min_sv_len=min_sv_len,
+                                                      max_sv_len=max_sv_len,
+                                                      sv_overlap=sv_overlap,
+                                                      sv_region_overlap=sv_region_overlap,
+                                                      sv_smooth=sv_smooth,
                                                       bed_id = bed_id, out_name=out_name).rv()
                                                     
                     if not clip_only:
@@ -693,8 +707,12 @@ def run_calleval(job, context, xg_ids, gam_ids, gam_idx_ids, bam_ids, bam_idx_id
                         if sveval:
                             sveval_results[out_name]["unclipped"] = \
                             call_job.addFollowOnJobFn(run_sv_eval, context, sample_name, vcf_tbi_id_pair,
-                                                      truth_vcf_id, truth_vcf_tbi_id, min_sv_len=25,
-                                                      sv_overlap=0.5, sv_region_overlap=1,
+                                                      truth_vcf_id, truth_vcf_tbi_id,
+                                                      min_sv_len=min_sv_len,
+                                                      max_sv_len=max_sv_len,
+                                                      sv_overlap=sv_overlap,
+                                                      sv_region_overlap=sv_region_overlap,
+                                                      sv_smooth=sv_smooth,
                                                       bed_id = None,
                                                       out_name=out_name if not bed_id else out_name + '-unclipped').rv()
                             
@@ -823,6 +841,11 @@ def calleval_main(context, options):
                                      options.happy,
                                      options.sveval,
                                      options.recall,
+                                     options.min_sv_len,
+                                     options.max_sv_len,
+                                     options.sv_overlap,
+                                     options.sv_region_overlap,
+                                     options.sv_smooth,
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -5,7 +5,7 @@ along with the other toil-vg output.  Can be run standalone as well.
 """
 from __future__ import print_function
 import argparse, sys, os, os.path, random, subprocess, shutil, itertools, glob
-import json, time, timeit, errno
+import json, time, timeit, errno, vcf
 from uuid import uuid4
 import logging
 
@@ -456,6 +456,60 @@ def run_happy(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeva
         "archive": out_archive_id
     }
 
+def vcf_to_bed(vcf_path, bed_path = None, ins_bed_path = None, del_bed_path = None,
+               indel_bed_path = None, snp_bed_path = None, multi_allele = 'max'):
+    """ Convert a VCF into a bed file that we can use bedtools intersection tools on.  Used to use
+    bedops' bed2vcf but it can't handle really long lines that come up in long SVs.  Indels are 
+    expanded to cover their starting position plus length.  This doesn't make a whole lot of 
+    sense for insertions, but it's useful for comparison purposes."""
+    if bed_path:
+        bed_file = open(bed_path, 'w')
+    if ins_bed_path:
+        ins_bed_file = open(ins_bed_path, 'w')
+    if del_bed_path:
+        del_bed_file = open(del_bed_path, 'w')
+    if indel_bed_path:
+        del_bed_file = open(indel_bed_path, 'w')
+    if snp_bed_path:
+        snp_bed_file = open(snp_bed_path, 'w')
+
+    with open(vcf_path, 'r') as vcf_file:
+        vcf_reader = vcf.Reader(vcf_file)
+        for record in vcf_reader:
+            # Find the longest alt.  If multi_allele is set to 'max', we ignore everything
+            # else.  Eventually we want to enhance the rest of the comparison to properly
+            # handle genotypes.
+            max_alt_idx, max_alt_len = -1, 0
+            for i, alt in enumerate(record.ALT):
+                if alt and len(alt) > max_alt_len:
+                    max_alt_idx, max_alt_len = i, len(alt)                    
+            for i, alt in enumerate(record.ALT):
+                if record.REF is not None and alt is not None and (i == max_alt_idx or multi_allele != 'max'):
+                    bed_line = '{}\t{}\t{}\t{}\n'.format(
+                        record.CHROM, record.POS - 1, record.POS - 1 + max(len(record.REF), len(alt)),
+                        '{} {} {}'.format(record.REF, alt, record.QUAL))
+                    if bed_path:
+                        bed_file.write(bed_line)
+                    if ins_bed_path and len(record.REF) < len(alt):
+                        ins_bed_file.write(bed_line)
+                    elif del_bed_path and len(record.REF) > len(alt):
+                        del_bed_file.write(bed_line)
+                    if indel_bed_path and len(record.REF) != len(alt):
+                        indel_bed_file.write(bed_line)
+                    elif snp_bed_path and len(record.REF) == len(alt):
+                        snp_bed_file.write(bed_line)
+
+    if bed_path:
+        bed_file.close()
+    if ins_bed_path:
+        ins_bed_file.close()
+    if del_bed_path:
+        del_bed_file.close()
+    if indel_bed_path:
+        indel_bed_file.close()
+    if snp_bed_path:
+        snp_bed_file.close()
+
 def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeval_baseline_tbi_id,
                 min_sv_len, sv_overlap, sv_region_overlap, sv_smooth = 0, bed_id = None,  out_name = ''):
     """ Run something like Peter Audano's bed-based comparison.  Uses bedtools and bedops to do
@@ -485,51 +539,18 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
     if out_name and not out_name.endswith('_'):
         out_name = '{}_'.format(out_name)
 
-    # convert vcfs to BEDs
-    call_bed_name = '{}calls.bed'.format(out_name)
-    baseline_bed_name = '{}truth.bed'.format(out_name)
-    for vcf_name, bed_name in zip([call_vcf_name, vcfeval_baseline_name], [call_bed_name, baseline_bed_name]):
-        # vg call sometimes makes IDs that are too long for bedops.  we zap the ids here just in case
-        temp_vcf_name = 'idfix-{}.vcf'.format(os.path.splitext(os.path.basename(vcf_name))[0])
-        with open(os.path.join(work_dir, temp_vcf_name), 'w') as temp_vcf_file:
-            context.runner.call(job, ['bcftools', 'view', '-h', vcf_name],
-                                work_dir = work_dir, outfile = temp_vcf_file)
-            context.runner.call(job, [['bcftools', 'view', '-H', vcf_name],
-                                      ['awk', '-F', '\t', '-v', 'OFS=\t', '{$3=\".\"; print $0;}']],
-                                work_dir = work_dir, outfile = temp_vcf_file)
-        # then convert the fixed if vcf into bed with bedops
-        with open(os.path.join(work_dir, bed_name + '.1del'), 'w') as bed_file:
-            vcf2bed_cmd = [['cat', temp_vcf_name], ['vcf2bed']]
-            context.runner.call(job, vcf2bed_cmd, work_dir = work_dir, outfile = bed_file, tool_name = 'bedops')
-            
-        # then expand the deletions, as vcf2bed writes them all with 1-sized intervals for some reason
-        expand_deletions(os.path.join(work_dir, bed_name + '.1del'), os.path.join(work_dir, bed_name))
-
-    # if the region bed's there, intersect both the calls and baseline       
-    if bed_id:
-        clipped_calls_name = "{}clipped_calls.bed".format(out_name)
-        clipped_baseline_name = "{}clipped_baseline.bed".format(out_name)
-
-        """
-        bedtools intersect -a SV_FILE.bed -b sd_regions_200_0.bed -wa -f 0.50 -u
-
-        * Get all SV variants that intersect SDs
-        * -wa: Print whole SV record (not just the intersecting part)
-        * -f 0.50: Require 50% of the SV to be in the SD
-        * Prevents very large DELs from being tagged if they intersect with part of a region.
-        * -u: Print matching SV call only once (even if it intersects with multiple variants)
-        * Probably has no effect because of -f 0.50 and the way merging is done, but I leave it in in case I tweak something.
-        """
-        for bed_name, clipped_bed_name in zip([call_bed_name, baseline_bed_name],
-                                              [clipped_calls_name, clipped_baseline_name]):
-            with open(os.path.join(work_dir, clipped_bed_name), 'w') as clipped_bed_file:
-                context.runner.call(job, ['bedtools', 'intersect', '-a', bed_name, '-b', regions_bed_name,
-                                          '-wa', '-f', str(sv_region_overlap), '-u'],
-                                    work_dir = work_dir, outfile = clipped_bed_file)
-    else:
-        clipped_calls_name = call_bed_name
-        clipped_baseline_name = baseline_bed_name
-        
+    # convert vcfs to BEDs, making and indel, insertions anda deletions bed for each vcf
+    calls_ins_name = '{}calls-ins.bed'.format(out_name)
+    calls_del_name = '{}calls-del.bed'.format(out_name)
+    baseline_ins_name = '{}truth-ins.bed'.format(out_name)
+    baseline_del_name = '{}truth-del.bed'.format(out_name)
+    vcf_to_bed(os.path.join(work_dir, call_vcf_name),
+               ins_bed_path = os.path.join(work_dir, calls_ins_name),
+               del_bed_path = os.path.join(work_dir, calls_del_name))
+    vcf_to_bed(os.path.join(work_dir, vcfeval_baseline_name),
+               ins_bed_path = os.path.join(work_dir, baseline_ins_name),
+               del_bed_path = os.path.join(work_dir, baseline_del_name))
+    
     # now do the intersection comparison
 
     """
@@ -542,18 +563,6 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
     * Same bedtools command as before, but with "-r" to force A to overlap with B by 50% AND B to overlap with A by 50%. "-u" becomes important because clustered insertions (common in tandem repeats) will overlap with more than one variant.
     """
 
-    # expand the bed regions to include the insertion lengths for both sets.
-    # we also break insertions and deletions into separate file.  Otherwise, insertions can
-    # intersect with deletions, inflating our accuracy.
-    clipped_calls_ins_name = '{}ins_calls.bed'.format(out_name)
-    clipped_baseline_ins_name = '{}ins_calls_baseline.bed'.format(out_name)
-    clipped_calls_del_name = '{}del_calls.bed'.format(out_name)
-    clipped_baseline_del_name = '{}del_calls_baseline.bed'.format(out_name)
-    expand_insertions(os.path.join(work_dir, clipped_calls_name), os.path.join(work_dir, clipped_calls_ins_name),
-                      os.path.join(work_dir, clipped_calls_del_name), min_sv_len)
-    expand_insertions(os.path.join(work_dir, clipped_baseline_name), os.path.join(work_dir, clipped_baseline_ins_name),
-                      os.path.join(work_dir, clipped_baseline_del_name), min_sv_len)
-
     tp_ins_name = '{}ins-TP-call.bed'.format(out_name)
     tp_del_name = '{}del-TP-call.bed'.format(out_name)
     tp_ins_rev_name = '{}ins-TP-baseline.bed'.format(out_name)
@@ -562,43 +571,62 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
     fp_del_name = '{}del-FP.bed'.format(out_name)
     fn_ins_name = '{}ins-FN.bed'.format(out_name)
     fn_del_name = '{}del-FN.bed'.format(out_name)        
-    for tp_indel_name, tp_indel_rev_name, calls_bed_indel_name, baseline_bed_indel_name, fp_indel_name, fn_indel_name in \
-        [(tp_ins_name, tp_ins_rev_name, clipped_calls_ins_name, clipped_baseline_ins_name, fp_ins_name, fn_ins_name),
-         (tp_del_name, tp_del_rev_name, clipped_calls_del_name, clipped_baseline_del_name, fp_del_name, fn_del_name)]:
+    for tp_name, tp_rev_name, calls_bed_name, baseline_bed_name, fp_name, fn_name in \
+        [(tp_ins_name, tp_ins_rev_name, calls_ins_name, baseline_ins_name, fp_ins_name, fn_ins_name),
+         (tp_del_name, tp_del_rev_name, calls_del_name, baseline_del_name, fp_del_name, fn_del_name)]:
 
         # smooth out features so, say, two side-by-side deltions get treated as one.  this is in keeping with
         # the coarse-grained nature of the analysis and is optional
         if sv_smooth > 0:
-            calls_merge_name = calls_bed_indel_name[:-4] + '_merge.bed'
-            baseline_merge_name = baseline_bed_indel_name[:-4] + '_merge.bed'            
+            calls_merge_name = calls_bed_name[:-4] + '_merge.bed'
+            baseline_merge_name = baseline_bed_name[:-4] + '_merge.bed'            
             with open(os.path.join(work_dir, calls_merge_name), 'w') as calls_merge_file:
-                context.runner.call(job, ['bedtools', 'merge', '-d', str(sv_smooth), '-i', calls_bed_indel_name],
+                context.runner.call(job, ['bedtools', 'merge', '-d', str(sv_smooth), '-i', calls_bed_name],
                                     work_dir = work_dir, outfile = calls_merge_file)
             with open(os.path.join(work_dir, baseline_merge_name), 'w') as baseline_merge_file:
-                context.runner.call(job, ['bedtools', 'merge', '-d', str(sv_smooth), '-i', baseline_bed_indel_name],
+                context.runner.call(job, ['bedtools', 'merge', '-d', str(sv_smooth), '-i', baseline_bed_name],
                                     work_dir = work_dir, outfile = baseline_merge_file)
-            calls_bed_indel_name = calls_merge_name
-            baseline_bed_indel_name = baseline_merge_name
+            calls_bed_name = calls_merge_name
+            baseline_bed_name = baseline_merge_name
+
+        def clip_cmd(cmd):
+            """
+            bedtools intersect -a SV_FILE.bed -b sd_regions_200_0.bed -wa -f 0.50 -u
+            
+            * Get all SV variants that intersect SDs
+            * -wa: Print whole SV record (not just the intersecting part)
+            * -f 0.50: Require 50% of the SV to be in the SD
+            * Prevents very large DELs from being tagged if they intersect with part of a region.
+            * -u: Print matching SV call only once (even if it intersects with multiple variants)
+            * Probably has no effect because of -f 0.50 and the way merging is done, but I leave it in in case I tweak something.
+            """            
+            if bed_id:
+                return [cmd, ['bedtools', 'intersect', '-a', '-', '-b', regions_bed_name,
+                              '-wa', '-f', str(sv_region_overlap), '-u']]
+            else:
+                return cmd
         
         # run the 50% overlap test described above for insertions and deletions
-        with open(os.path.join(work_dir, tp_indel_name), 'w') as tp_file:
-            context.runner.call(job, ['bedtools', 'intersect', '-a', calls_bed_indel_name,
-                                  '-b', baseline_bed_indel_name, '-wa', '-f', str(sv_overlap), '-r', '-u'],
-                            work_dir = work_dir, outfile = tp_file)            
+        with open(os.path.join(work_dir, tp_name), 'w') as tp_file:
+            context.runner.call(job, clip_cmd(['bedtools', 'intersect', '-a', calls_bed_name, '-b',
+                                               baseline_bed_name, '-wa', '-f', str(sv_overlap), '-r', '-u']),
+                                work_dir = work_dir, outfile = tp_file)            
         # we run other way so we can get false positives from the calls and true positives from the baseline    
-        with open(os.path.join(work_dir, tp_indel_rev_name), 'w') as tp_file:        
-            context.runner.call(job, ['bedtools', 'intersect', '-b', calls_bed_indel_name,
-                                  '-a', baseline_bed_indel_name, '-wa', '-f', str(sv_overlap), '-r', '-u'],
-                            work_dir = work_dir, outfile = tp_file)
+        with open(os.path.join(work_dir, tp_rev_name), 'w') as tp_rev_file:        
+            context.runner.call(job, clip_cmd(['bedtools', 'intersect', '-b', calls_bed_name, '-a',
+                                               baseline_bed_name, '-wa', '-f', str(sv_overlap), '-r', '-u']),
+                                work_dir = work_dir, outfile = tp_rev_file)
         # put the false positives in their own file
-        with open(os.path.join(work_dir, fp_indel_name), 'w') as fp_file:
-            context.runner.call(job, ['bedtools', 'subtract', '-a', calls_bed_indel_name,
-                                      '-b', tp_indel_name], work_dir = work_dir, outfile = fp_file)
+        with open(os.path.join(work_dir, fp_name), 'w') as fp_file:
+            context.runner.call(job, clip_cmd(['bedtools', 'subtract', '-a', calls_bed_name, '-b', tp_name,
+                                               '-f' ,'1.0', '-r']),
+                                work_dir = work_dir, outfile = fp_file)
         # and the false negatives
-        with open(os.path.join(work_dir, fn_indel_name), 'w') as fn_file:
-            context.runner.call(job, ['bedtools', 'subtract', '-a', baseline_bed_indel_name,
-                                      '-b', tp_indel_rev_name], work_dir = work_dir, outfile = fn_file)
-        # todo: should we write them out in vcf as well?
+        with open(os.path.join(work_dir, fn_name), 'w') as fn_file:
+            context.runner.call(job, clip_cmd(['bedtools', 'subtract', '-a', baseline_bed_name, '-b',
+                                               tp_rev_name, '-f', '1.0', '-r']),
+                                work_dir = work_dir, outfile = fn_file)
+        # todo: should we write them out in vcf as well? yes
 
     # summarize results into a table
     results = summarize_sv_results(os.path.join(work_dir, tp_ins_name),


### PR DESCRIPTION
Fixes #640.   Combined with other changes, the caller's up past 95% recall on insertions using real reads on the normalized HGSVC graph (chr21 outside repetitive regions).  Overall SV F1 at 91%.  The remaining insertion false negatives have very little read support.

