### PR TITLE
merge records at same position in sveval normalization

### DIFF
--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -564,7 +564,8 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
                                     (vcfeval_baseline_name, norm_vcfeval_baseline_name)]:
             with open(os.path.join(work_dir, norm_name), 'w') as norm_file:
                 context.runner.call(job, ['bcftools', 'norm', vcf_name, '--output-type', 'z',
-                                      '--fasta-ref', fasta_name], work_dir = work_dir, outfile=norm_file)
+                                          '--fasta-ref', fasta_name, '--multiallelics', '+'],
+                                    work_dir = work_dir, outfile=norm_file)
                 context.runner.call(job, ['tabix', '--preset', 'vcf', norm_name], work_dir = work_dir)
         call_vcf_name = norm_call_vcf_name
         vcfeval_baseline_name = norm_vcfeval_baseline_name


### PR DESCRIPTION
bcftools norm can cause seperate indels to wind up in the same position.  Add option to merge them into one record rather than having several lines at same position.  This is more consistent with rest of the data, but still a case not handled properly by overlap comparison logic