### PR TITLE
dont normalize haplo graph

### DIFF
--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -421,7 +421,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                           max_node_size, gbwt_index or haplo_extraction or alt_paths,
                                           flat_alts, regions,
                                           region_names, sort_ids, join_ids, name, merge_output_name,
-                                          normalize)
+                                          normalize and name != 'haplo')
 
         mapping_id = construct_job.rv('mapping')
         


### PR DESCRIPTION
I had a simulation go very wrong for reasons I can't figure out, and the only thing changed seems to be the normalize flag going into construction.  Will force it off for these graphs until I can convince myself the problem was elsewhere (also, there's no reason I can think of to normalize the haplo graphs..)