### PR TITLE
De-pipe Mac docker

### DIFF
--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -15,6 +15,9 @@ import pkg_resources, tempfile, datetime
 import logging
 from distutils.spawn import find_executable
 import collections
+import socket
+import uuid
+import platform
 
 from toil.common import Toil
 from toil.job import Job
@@ -259,19 +262,62 @@ to do: Should go somewhere more central """
             # We can't just redirect stdout of the container from the API, so
             # we do something more complicated.
             
-            # Set up a FIFO to receive it
-            fifo_dir = tempfile.mkdtemp()
-            fifo_host_path = os.path.join(fifo_dir, 'stdout.fifo')
-            os.mkfifo(fifo_host_path)
+            # Now we need to populate an FD that spits out the container output.
+            output_fd = None
             
-            # Mount the FIFO in the container.
-            # The container doesn't actually have to have the mountpoint directory in its filesystem.
-            volumes[fifo_dir] = {'bind': '/control', 'mode': 'rw'}
+            # We may be able to use a FIFO, or we may need a network connection.
+            # FIFO sharing between host and container only works on Linux.
+            use_fifo = (platform.system() == 'Linux')
             
-            # Redirect the command output by tacking on another pipeline stage
-            parameters = args + [['dd', 'of=/control/stdout.fifo']]
-            
-            
+            if use_fifo:
+                # On a Linux host we can just use a FIFO from the container to the host
+                
+                # Set up a FIFO to receive it
+                fifo_dir = tempfile.mkdtemp()
+                fifo_host_path = os.path.join(fifo_dir, 'stdout.fifo')
+                os.mkfifo(fifo_host_path)
+                
+                # Mount the FIFO in the container.
+                # The container doesn't actually have to have the mountpoint directory in its filesystem.
+                volumes[fifo_dir] = {'bind': '/control', 'mode': 'rw'}
+                
+                # Redirect the command output by tacking on another pipeline stage
+                parameters = args + [['dd', 'of=/control/stdout.fifo']]
+                
+                # Open the FIFO into nonblocking mode. See
+                # <https://stackoverflow.com/a/5749687> and
+                # <http://shallowsky.com/blog/programming/python-read-characters.html>
+                output_fd = os.open(fifo_host_path, os.O_RDONLY | os.O_NONBLOCK)
+                
+            else:
+                # On a Mac host we can't because of https://github.com/docker/for-mac/issues/483
+                # We need to go over the network instead.
+                
+                # Open an IPv4 TCP socket, since we know Docker uses IPv4 only
+                listen_sock = socket.socket(socket.AF_INET)
+                # Bind it to an OS-selected port on all interfaces, since we can't determine the Docker interface
+                listen_sock.bind((socket.INADDR_ANY, 0))
+                
+                # Start listening
+                listen_sock.listen(1)
+                
+                # Get the port we got given
+                listen_port = listen_sock.getsockname()[1]
+                
+                # Generate a random security cookie. Since we can't really stop
+                # Internet randos from connecting to our socket, we bail out on
+                # any connection that doesn't start with this cookie and a newline.
+                security_cookie = str(uuid.uuid4())
+                
+                # Redirect the command output to that port using Bash networking
+                # Your Docker needs to be 18.03+ to support host.docker.internal
+                # Your container needs to have bash with networking support
+                parameters = args + [['bash', '-c', 'exec 3<>/dev/tcp/host.docker.internal/{}; cat <({}) - >&3'.format(
+                    listen_port, security_cookie)]]
+                
+                # We can't populate the FD until we accept, which we can't do
+                # until the Docker comes up and is trying to connect.
+                
             # Start the container detached so we don't wait on it
             container = apiDockerCall(job, tool, parameters,
                                       volumes=volumes,
@@ -282,14 +328,41 @@ to do: Should go somewhere more central """
             
             RealtimeLogger.debug("Asked for container {}".format(container.id))
             
-            # If the Docker container goes badly enough, it may not even
-            # open the other end of the FIFO. So we can't just wait for it
-            # to EOF before checking on the Docker.
-            
-            # Open the FIFO into nonblocking mode. See
-            # <https://stackoverflow.com/a/5749687> and
-            # <http://shallowsky.com/blog/programming/python-read-characters.html>
-            fifo_fd = os.open(fifo_host_path, os.O_RDONLY | os.O_NONBLOCK)
+            if not use_fifo:
+                # Try and accept a connection from the container.
+                # Make sure there's a timeout so we don't accept forever
+                listen_sock.settimeout(10)
+                
+                for attempt in range(3):
+                
+                    connection_sock, remote_address = listen_sock.accept()
+                    
+                    # Set a 10 second timeout for the cookie
+                    connection_sock.settimeout(10)
+                    
+                    # Check the security cookie
+                    received_cookie_and_newline = connection_sock.recv(len(security_cookie) + 1)
+                    
+                    if received_cookie_and_newline != security_cookie + '/n':
+                        # Incorrect security cookie.
+                        RealtimeLogger.warning("Received incorect security cookie message from {}: {}".format(
+                            remote_address, received_cookie_and_newline))
+                        continue
+                    else:
+                        # This is the container we are looking for
+                        # Go into nonblocking mode which our read code expects
+                        connection_sock.setblocking(True)
+                        # Set the FD
+                        output_fd = connection_sock.fileno()
+                        break
+
+                if output_fd is None:
+                    # We can't get ahold of the Docker in time
+                    raise RuntimeError("Could not establish network connection for Docker output!")
+                    
+            # If the Docker container goes badly enough, it may not even open
+            # the other end of the connection. So we can't just wait for it to
+            # EOF before checking on the Docker.
             
             # Now read ought to throw if there is no data. But
             # <https://stackoverflow.com/q/38843278> and some testing suggest
@@ -309,15 +382,16 @@ to do: Should go somewhere more central """
                 while True:
                     # While there still might be data in the pipe
                     
-                    # Select on the pipe with a timeout, so we don't spin constantly waiting for data
-                    can_read, can_write, had_error = select.select([fifo_fd], [], [fifo_fd], 10)
+                    if output_fd is not None:
+                        # Select on the pipe with a timeout, so we don't spin constantly waiting for data
+                        can_read, can_write, had_error = select.select([output_fd], [], [output_fd], 10)
                     
                     if len(can_read) > 0 or len(had_error) > 0:
                         # There is data available or something else weird about our FIFO.
                     
                         try:
                             # Do a nonblocking read. Since we checked with select we never should get "" unless there's an EOF.
-                            data = os.read(fifo_fd, 4096)
+                            data = os.read(output_fd, 4096)
                             
                             if data == "":
                                 # We didn't throw and we got nothing, so it must be EOF.
@@ -362,16 +436,22 @@ to do: Should go somewhere more central """
                             continue
                             
             finally:
-                # No matter what happens, close our end of the FIFO
-                os.close(fifo_fd)
+                # No matter what happens, close our end of the connection
+                os.close(output_fd)
+                
+                if not use_fifo:
+                    # Also close the listening socket
+                    listen_sock.close()
                     
                         
             # Now our data is all sent.
             # Wait on the container and get its return code.
             return_code = container.wait()
             
-            os.unlink(fifo_host_path)
-            os.rmdir(fifo_dir)
+            if use_fifo:
+                # Clean up the FIFO files
+                os.unlink(fifo_host_path)
+                os.rmdir(fifo_dir)
             
         else:
             # No piping needed.


### PR DESCRIPTION
Here's my attempt to fix #661.

I'm working around the lack of FIFO-out-of-the-container support by using a network connection when running on Mac. I have to listen on all interfaces, because I don't have a good way to identify the Docker interface, so I'm making the container send back a random cookie to prove the network connection came from where it was supposed to.

This doesn't actually do anything about the `APIError: 502 Server Error: Bad Gateway ("Mounts denied:...` message. I found that that could be dealt with by just exposing `/var/folders` as mountable in containers:

<img width="512" alt="screen shot 2018-12-12 at 4 41 04 pm" src="https://user-images.githubusercontent.com/5062495/49907834-c14f0e80-fe2c-11e8-9a13-921ee57e6b1f.png">

@eldariont does that approach work for you? It might be that something changed in an OS update that would cause it to work for me and not for you.

We could have our own logic in toil-vg to tell people to add `/var/folders`, or to move their temp directories, or just move their temp directories for them, but I feel like the Docker error message might be enough, if following its instructions actually helps. Maybe we could put something in the toil-vg README.

