### PR TITLE
Parallelize parsing and compression of position results files

### DIFF
--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -898,15 +898,16 @@ def ensure_disk(job, job_fn, job_fn_args, job_fn_kwargs, file_id_list, factor=8,
         # Disk we have is OK
         return None
         
-def run_concat_files(job, context, file_ids, name=None, header=None):
+def run_concat_files(job, context, file_ids, dest_name=None, header=None):
     """
     Utility job to concatenate some files. Returns the concatenated file ID.
-    If given a name, writes the result to the out store with the given name.
+    If given a dest_name, writes the result to the out store with the given name.
+    (We wanted to use name, but that kwarg is reserved by Toil.)
     If given a header, prepends the header to the file with a trailing newline.
     """
     
     requeue_promise = ensure_disk(job, run_concat_files, [context, file_ids],
-        {"name": name, "header": header}, file_ids, factor=2)
+        {"dest_name": dest_name, "header": header}, file_ids, factor=2)
     if requeue_promise is not None:
         # We requeued ourselves with more disk to accomodate our inputs
         return requeue_promise
@@ -914,7 +915,7 @@ def run_concat_files(job, context, file_ids, name=None, header=None):
     
     work_dir = job.fileStore.getLocalTempDir()
 
-    out_name = os.path.join(work_dir, 'output.dat' if name is None else name)
+    out_name = os.path.join(work_dir, 'output.dat' if dest_name is None else dest_name)
 
     # Concatenate all the files
     # TODO: We don't use the trick where we append to the first file to save a copy. Should we?
@@ -927,11 +928,13 @@ def run_concat_files(job, context, file_ids, name=None, header=None):
                 # Then beam over each file
                 shutil.copyfileobj(in_file, out_file)
 
-    if name is None:
+    if dest_name is None:
         # Send back an intermediate file
+        RealtimeLogger.info("Concatenated {} files into intermediate file {}".format(len(file_ids), out_name)) 
         return context.write_intermediate_file(job, out_name)
     else:
         # Write to outstore under the given name.
-        return context.write_output_file(job, out_name, name)
+        RealtimeLogger.info("Concatenated {} files into output file {} -> {}".format(len(file_ids), out_name, dest_name)) 
+        return context.write_output_file(job, out_name, dest_name)
             
 

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -897,5 +897,41 @@ def ensure_disk(job, job_fn, job_fn_args, job_fn_kwargs, file_id_list, factor=8,
     else:
         # Disk we have is OK
         return None
+        
+def run_concat_files(job, context, file_ids, name=None, header=None):
+    """
+    Utility job to concatenate some files. Returns the concatenated file ID.
+    If given a name, writes the result to the out store with the given name.
+    If given a header, prepends the header to the file with a trailing newline.
+    """
+    
+    requeue_promise = ensure_disk(job, run_concat_files, [context, file_ids],
+        {"name": name, "header": header}, file_ids, factor=2)
+    if requeue_promise is not None:
+        # We requeued ourselves with more disk to accomodate our inputs
+        return requeue_promise
+
+    
+    work_dir = job.fileStore.getLocalTempDir()
+
+    out_name = os.path.join(work_dir, 'output.dat' if name is None else name)
+
+    # Concatenate all the files
+    # TODO: We don't use the trick where we append to the first file to save a copy. Should we?
+    with open(out_name, 'w') as out_file:
+        if header is not None:
+            # Put the header if specified
+            out_file.write(header + '\n')
+        for file_id in file_ids:
+            with job.fileStore.readGlobalFileStream(file_id) as in_file:
+                # Then beam over each file
+                shutil.copyfileobj(in_file, out_file)
+
+    if name is None:
+        # Send back an intermediate file
+        return context.write_intermediate_file(job, out_name)
+    else:
+        # Write to outstore under the given name.
+        return context.write_output_file(job, out_name, name)
             
 

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -581,32 +581,6 @@ def run_cat_xg_indexing(job, context, inputGraphFileIDs, graph_names, index_name
                                       disk=job.disk,
                                       preemptable=job.preemptable).rv()
                                       
-def run_concat_files(job, context, file_ids, name=None):
-    """
-    Utility job to concatenate some files. Returns the concatenated file ID.
-    If given a name, writes the result to the out store with the given name.
-    """
-    work_dir = job.fileStore.getLocalTempDir()
-
-    # Download all the files
-    file_names = [job.fileStore.readGlobalFile(file_id) for file_id in file_ids]
-
-    out_name = os.path.join(work_dir, 'output.dat')
-
-    # Concatenate all the files
-    # TODO: We don't use the trick where we append to the first file to save a copy. Should we?
-    with open(out_name, 'w') as out_file:
-        for file_name in file_names:
-            with open(file_name) as in_file:
-                shutil.copyfileobj(in_file, out_file)
-
-    if name is None:
-        # Send back an intermediate file
-        return context.write_intermediate_file(job, out_name)
-    else:
-        # Write to outstore under the given name.
-        return context.write_output_file(job, out_name, name)
-    
 def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name=None):
     """
     Compute the snarls of the graph.

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -1932,7 +1932,7 @@ def run_process_position_comparisons(job, context, compare_ids):
     # Return the position stats file, built from all the individual stat calculations, and the concatenated position.results.tsv.
     return (job.addFollowOnJobFn(run_write_position_stats, context, map_stats).rv(),
         job.addFollowOnJobFn(run_concat_files, context, results_files,
-            name='position.results.tsv',
+            dest_name='position.results.tsv',
             header='\t'.join(['correct', 'mq', 'tags', 'aligner', 'read', 'count'])).rv())
     
 def run_summarize_position_comparison(job, context, compare_id, aligner_name):


### PR DESCRIPTION
One of the slowest steps in `toil-vg mapeval` with lots of conditions is `run_process_position_comparisons`, because it touches every read in every condition serially.

I'm modifying it here to push the compression of correct reads into per-condition jobs, with `run_process_position_comparisons` just asking for those jobs' results to be concatenated. This should hopefully improve performance.