### PR TITLE
Wrapper for reading JobStore files

### DIFF
--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -129,13 +129,13 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
 
     # Read our input files from the store
     vg_path = os.path.join(work_dir, '{}.vg'.format(chunk_name))
-    job.fileStore.readGlobalFile(vg_id, vg_path)
+    context.read_jobstore_file(job, vg_id, vg_path)
     gam_path = os.path.join(work_dir, '{}.gam'.format(chunk_name))
-    job.fileStore.readGlobalFile(gam_id, gam_path)
+    context.read_jobstore_file(job, gam_id, gam_path)
     xg_path = os.path.join(work_dir, '{}.xg'.format(chunk_name))
     defray = filter_opts and ('-D' in filter_opts or '--defray-ends' in filter_opts)
     if xg_id and defray:
-        job.fileStore.readGlobalFile(xg_id, xg_path)
+        context.read_jobstore_file(job, xg_id, xg_path)
         
     # Define paths for all the files we might make
     pu_path = os.path.join(work_dir, '{}.pu'.format(chunk_name))
@@ -344,13 +344,13 @@ def run_vg_genotype(job, context, sample_name, vg_id, gam_id, xg_id = None,
 
     # Read our input files from the store
     vg_path = os.path.join(work_dir, '{}.vg'.format(chunk_name))
-    job.fileStore.readGlobalFile(vg_id, vg_path)
+    context.read_jobstore_file(job, vg_id, vg_path)
     gam_path = os.path.join(work_dir, '{}.gam'.format(chunk_name))
-    job.fileStore.readGlobalFile(gam_id, gam_path)
+    context.read_jobstore_file(job, gam_id, gam_path)
     xg_path = os.path.join(work_dir, '{}.xg'.format(chunk_name))
     defray = filter_opts and ('-D' in filter_opts or '--defray-ends' in filter_opts)
     if xg_id and defray:
-        job.fileStore.readGlobalFile(xg_id, xg_path)
+        context.read_jobstore_file(job, xg_id, xg_path)
         
     # we only need an xg if using vg filter -D
     if not xg_id and defray:
@@ -480,7 +480,7 @@ def run_clip_vcf(job, context, path_name, chunk_i, num_chunks, chunk_offset, cli
 
     # output vcf name
     vcf_path = os.path.join(work_dir, 'chunk_{}_{}.vcf'.format(path_name, chunk_offset))
-    job.fileStore.readGlobalFile(vcf_id, vcf_path + '.us')
+    context.read_jobstore_file(job, vcf_id, vcf_path + '.us')
     
     # Sort the output
     sort_vcf(job, context.runner, vcf_path + '.us', vcf_path)
@@ -559,8 +559,8 @@ def run_merge_vcf(job, context, out_name, vcf_tbi_file_id_pair_list, call_timers
     for i, vcf_tbi_file_id_pair in enumerate(vcf_tbi_file_id_pair_list):
         vcf_file = os.path.join(work_dir, 'vcf_chunk_{}.vcf.gz'.format(i))
         vcf_file_idx = '{}.tbi'.format(vcf_file)
-        job.fileStore.readGlobalFile(vcf_tbi_file_id_pair[0], vcf_file)
-        job.fileStore.readGlobalFile(vcf_tbi_file_id_pair[1], vcf_file_idx)
+        context.read_jobstore_file(job, vcf_tbi_file_id_pair[0], vcf_file, cache=False)
+        context.read_jobstore_file(job, vcf_tbi_file_id_pair[1], vcf_file_idx, cache=False)
         vcf_merging_file_key_list.append(os.path.basename(vcf_file))
 
     vcf_merged_file_key = "" 
@@ -612,16 +612,16 @@ def run_calling(job, context, xg_file_id, alignment_file_id, alignment_index_id,
 
     # Download the input from the store
     xg_path = os.path.join(work_dir, 'graph.vg.xg')
-    job.fileStore.readGlobalFile(xg_file_id, xg_path)
+    context.read_jobstore_file(job, xg_file_id, xg_path)
     gam_path = os.path.join(work_dir, '{}_{}.gam'.format(sample_name, tag))
-    job.fileStore.readGlobalFile(alignment_file_id, gam_path)
+    context.read_jobstore_file(job, alignment_file_id, gam_path)
 
     # Sort and index the GAM file if index not provided
     timer = TimeTracker('call-gam-index')    
     if alignment_index_id:
         gam_sort_path = gam_path
         gam_index_path = gam_sort_path + '.gai'
-        job.fileStore.readGlobalFile(alignment_index_id, gam_index_path)
+        context.read_jobstore_file(job, alignment_index_id, gam_index_path)
     else:
         gam_sort_path = gam_path + '.sorted.gam'
         gam_index_path = gam_sort_path + '.gai'
@@ -740,7 +740,7 @@ def run_merge_vcf_chunks(job, context, path_name, clip_file_ids):
         
         # Download clip.vcf file from the store
         clip_path = os.path.join(work_dir, 'clip_{}.vcf'.format(chunk_i))
-        job.fileStore.readGlobalFile(clip_file_id, clip_path)
+        context.read_jobstore_file(job, clip_file_id, clip_path, cache=False)
 
         if chunk_i == 0:
             # copy everything including the header

--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -146,7 +146,7 @@ def run_bam_index(job, context, bam_file_id, bam_name):
 
     # download the input
     bam_path = os.path.join(work_dir, bam_name + '.bam')
-    job.fileStore.readGlobalFile(bam_file_id, bam_path)
+    context.read_jobstore_file(job, bam_file_id, bam_path)
 
     sort_bam_path = os.path.join(work_dir, 'sort.bam')
     sort_cmd = ['samtools', 'sort', os.path.basename(bam_path), '-o',
@@ -204,9 +204,9 @@ def run_bam_caller(job, context, fasta_file_id, bam_file_id, bam_idx_id,
     fasta_path = os.path.join(work_dir, 'ref.fa')
     bam_path = os.path.join(work_dir, 'alignment.bam')
     bam_idx_path = bam_path + '.bai'
-    job.fileStore.readGlobalFile(fasta_file_id, fasta_path)
-    job.fileStore.readGlobalFile(bam_file_id, bam_path)
-    job.fileStore.readGlobalFile(bam_idx_id, bam_idx_path)
+    context.read_jobstore_file(job, fasta_file_id, fasta_path)
+    context.read_jobstore_file(job, bam_file_id, bam_path)
+    context.read_jobstore_file(job, bam_idx_id, bam_idx_path)
 
     # output
     vcf_path = os.path.join(work_dir, '{}-raw.vcf'.format(out_name))
@@ -452,8 +452,8 @@ def run_vcf_subset(job, context, vcf_file_id, tbi_file_id, regions):
     # download the input
     vcf_path = os.path.join(work_dir, 'input.vcf.gz')
     out_vcf_path = os.path.join(work_dir, 'output.vcf.gz')
-    job.fileStore.readGlobalFile(vcf_file_id, vcf_path)
-    job.fileStore.readGlobalFile(tbi_file_id, vcf_path + '.tbi')
+    context.read_jobstore_file(job, vcf_file_id, vcf_path)
+    context.read_jobstore_file(job, tbi_file_id, vcf_path + '.tbi')
 
     cmd = ['bcftools', 'view', os.path.basename(vcf_path), '--regions', ','.join(regions),
            '--output-type', 'z', '--output-file', os.path.basename(out_vcf_path)]

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -691,12 +691,12 @@ def require(expression, message):
     if not expression:
         raise Exception('\n\n' + message + '\n\n')
 
-def parse_id_ranges(job, id_ranges_file_id):
+def parse_id_ranges(context, job, id_ranges_file_id):
     """Returns list of triples chrom, start, end
     """
     work_dir = job.fileStore.getLocalTempDir()
     id_range_file = os.path.join(work_dir, 'id_ranges.tsv')
-    job.fileStore.readGlobalFile(id_ranges_file_id, id_range_file)
+    context.read_jobstore_file(job, id_ranges_file_id, id_range_file)
     return parse_id_ranges_file(id_range_file)
 
 def parse_id_ranges_file(id_ranges_filename):

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -699,7 +699,11 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                 # many graphs again and maybe a single merged graph with the
                 # reference removed.
                 join_job = sample_job.addFollowOnJobFn(run_join_graphs, context, sample_job.rv(),
-                                                       False, region_names, name, sample_merge_output_name)
+                                                       False, region_names, name, sample_merge_output_name,
+                                                       cores=context.config.construct_cores,
+                                                       memory=context.config.construct_mem,
+                                                       disk=context.config.construct_disk)
+)
                 # Want to keep a whole-genome withref xg index around for mapeval purposes
                 if len(regions) > 1 and xg_index:
                     construct_job.addFollowOnJobFn(run_indexing, context, joined_vg_ids,
@@ -833,8 +837,10 @@ def run_construct_genome_graph(job, context, fasta_ids, fasta_names, vcf_ids, vc
                                                   disk=context.config.construct_disk).rv())
 
     return child_job.addFollowOnJobFn(run_join_graphs, context, region_graph_ids, join_ids,
-                                      region_names, name, merge_output_name).rv()
-
+                                      region_names, name, merge_output_name,
+                                      cores=context.config.construct_cores,
+                                      memory=context.config.construct_mem,
+                                      disk=context.config.construct_disk).rv()
 
 def run_join_graphs(job, context, region_graph_ids, join_ids, region_names, name, merge_output_name = None):
     """

--- a/src/toil_vg/vg_sim.py
+++ b/src/toil_vg/vg_sim.py
@@ -164,19 +164,19 @@ def run_sim_chunk(job, context, gam, seed_base, xg_file_id, xg_annot_file_id, nu
 
     # read the xg file
     xg_file = os.path.join(work_dir, 'index.xg')
-    job.fileStore.readGlobalFile(xg_file_id, xg_file)
+    context.read_jobstore_file(job, xg_file_id, xg_file)
 
     # read the fastq file
     if fastq_id:
         fastq_file = os.path.join(work_dir, 'error_template.fastq')
-        job.fileStore.readGlobalFile(fastq_id, fastq_file)
+        context.read_jobstore_file(job, fastq_id, fastq_file)
     else:
         fastq_file = None
     
     # and the annotation xg file
     if xg_annot_file_id:
         xg_annot_file = os.path.join(work_dir, 'annot_index.xg')
-        xg_annot_file = job.fileStore.readGlobalFile(xg_annot_file_id, xg_annot_file)
+        xg_annot_file = context.read_jobstore_file(job, xg_annot_file_id, xg_annot_file)
     else:
         xg_annot_file = xg_file
 
@@ -184,7 +184,7 @@ def run_sim_chunk(job, context, gam, seed_base, xg_file_id, xg_annot_file_id, nu
     tag_beds = []
     for i, bed_id in enumerate(tag_bed_ids):
         bed_file = os.path.join(work_dir, 'tag_{}.bed'.format(i))
-        job.fileStore.readGlobalFile(bed_id, bed_file)
+        context.read_jobstore_file(job, bed_id, bed_file)
         tag_beds.append(bed_file)
 
     # run vg sim
@@ -315,7 +315,7 @@ def run_merge_sim_chunks(job, context, gam, sim_out_id_infos, out_name):
         with open(merged_reads_file, 'a') as out_reads:
             for i, reads_file_id in enumerate(sim_out_id_infos):
                 reads_file = os.path.join(work_dir, 'sim_reads_{}'.format(i))
-                job.fileStore.readGlobalFile(reads_file_id, reads_file)
+                context.read_jobstore_file(job, reads_file_id, reads_file, cache=False)
                 with open(reads_file) as rf:
                     shutil.copyfileobj(rf, out_reads)
 
@@ -331,12 +331,12 @@ def run_merge_sim_chunks(job, context, gam, sim_out_id_infos, out_name):
             
             for i, sim_out_id_info in enumerate(sim_out_id_infos):
                 gam_file = os.path.join(work_dir, 'sim_{}.gam'.format(i))
-                job.fileStore.readGlobalFile(sim_out_id_info[0], gam_file)
+                context.read_jobstore_file(job, sim_out_id_info[0], gam_file, cache=False)
                 with open(gam_file) as rf:
                     shutil.copyfileobj(rf, out_gam)
                     
                 true_file = os.path.join(work_dir, 'true_{}.pos'.format(i))
-                job.fileStore.readGlobalFile(sim_out_id_info[1], true_file)
+                context.read_jobstore_file(job, sim_out_id_info[1], true_file, cache=False)
                 with open(true_file) as rf:
                     shutil.copyfileobj(rf, out_true)
 

--- a/src/toil_vg/vg_surject.py
+++ b/src/toil_vg/vg_surject.py
@@ -142,13 +142,13 @@ def run_chunk_surject(job, context, interleaved, xg_file_id, paths, chunk_filena
     work_dir = job.fileStore.getLocalTempDir()
 
     xg_file = os.path.join(work_dir, "index.xg")
-    job.fileStore.readGlobalFile(xg_file_id, xg_file)
+    context.read_jobstore_file(job, xg_file_id, xg_file)
 
     gam_files = []
     reads_ext = 'gam'
     for j, chunk_filename_id in enumerate(chunk_filename_ids):
         gam_file = os.path.join(work_dir, 'reads_chunk_{}_{}.{}'.format(chunk_id, j, reads_ext))
-        job.fileStore.readGlobalFile(chunk_filename_id, gam_file)
+        context.read_jobstore_file(job, chunk_filename_id, gam_file)
         gam_files.append(gam_file)
     
     # And a temp file for our surject output
@@ -214,7 +214,7 @@ def run_merge_bams(job, output_name, context, bam_chunk_file_ids):
     # Download our chunk files
     chunk_paths = [os.path.join(work_dir, 'chunk_{}.bam'.format(i)) for i in range(len(flat_ids))]
     for i, bam_chunk_file_id in enumerate(flat_ids):
-        job.fileStore.readGlobalFile(bam_chunk_file_id, chunk_paths[i])
+        context.read_jobstore_file(job, bam_chunk_file_id, chunk_paths[i])
 
     # todo: option to give name
     surject_path = os.path.join(work_dir, '{}.bam'.format(output_name))

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -294,7 +294,7 @@ def run_pipeline_call(job, context, options, xg_file_id, id_ranges_file_id, chr_
     """ Run variant calling on the chromosomes in parallel """
 
     if id_ranges_file_id:
-        chroms = [x[0] for x in parse_id_ranges(job, id_ranges_file_id)]
+        chroms = [x[0] for x in parse_id_ranges(context, job, id_ranges_file_id)]
     else:
         chroms = options.chroms
     assert len(chr_gam_ids) == len(chroms)

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -156,7 +156,7 @@ def run_vcfeval_roc_plot(job, context, roc_table_ids, names=[], kind=None, numbe
         # rtg gets naming information from directory structure, so we read each file into
         # its own dir
         os.makedirs(os.path.join(work_dir, name))
-        job.fileStore.readGlobalFile(file_id, table_path)
+        context.read_jobstore_file(job, file_id, table_path)
         RealtimeLogger.info('Downloaded {} to {}'.format(file_id, table_path))
 
     # Make sure the kind has 'roc' in it
@@ -205,8 +205,8 @@ def run_extract_sample_truth_vcf(job, context, sample, input_baseline_id, input_
     
     # Download the truth vcf
     vcfeval_baseline_name = 'full-truth.vcf.gz'
-    job.fileStore.readGlobalFile(input_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
-    job.fileStore.readGlobalFile(input_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))    
+    context.read_jobstore_file(job, input_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
+    context.read_jobstore_file(job, input_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))    
     
     # Make the single-sample VCF
     single_name = 'single-truth-{}.vcf.gz'.format(sample)
@@ -248,21 +248,21 @@ def run_vcfeval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
     # download the vcf
     call_vcf_id, call_tbi_id = vcf_tbi_id_pair[0], vcf_tbi_id_pair[1]
     call_vcf_name = "calls.vcf.gz"
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
 
     # and the truth vcf
     vcfeval_baseline_name = 'truth.vcf.gz'
-    job.fileStore.readGlobalFile(vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
-    job.fileStore.readGlobalFile(vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))    
+    context.read_jobstore_file(job, vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
+    context.read_jobstore_file(job, vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))    
     # download the fasta (make sure to keep input extension)
     fasta_name = "fa_" + os.path.basename(fasta_path)
-    job.fileStore.readGlobalFile(fasta_id, os.path.join(work_dir, fasta_name))
+    context.read_jobstore_file(job, fasta_id, os.path.join(work_dir, fasta_name))
 
     # download the bed regions
     bed_name = "bed_regions.bed" if bed_id else None
     if bed_id:
-        job.fileStore.readGlobalFile(bed_id, os.path.join(work_dir, bed_name))
+        context.read_jobstore_file(job, bed_id, os.path.join(work_dir, bed_name))
 
     # use out_name if specified, otherwise sample
     if sample and not out_name:
@@ -384,28 +384,28 @@ def run_happy(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeva
     # download the vcf
     call_vcf_id, call_tbi_id = vcf_tbi_id_pair[0], vcf_tbi_id_pair[1]
     call_vcf_name = "calls.vcf.gz"
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
 
     # and the truth vcf
     vcfeval_baseline_name = 'truth.vcf.gz'
-    job.fileStore.readGlobalFile(vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
-    job.fileStore.readGlobalFile(vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
+    context.read_jobstore_file(job, vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
+    context.read_jobstore_file(job, vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
     
     # download the fasta (make sure to keep input extension)
     fasta_name = "fa_" + os.path.basename(fasta_path)
-    job.fileStore.readGlobalFile(fasta_id, os.path.join(work_dir, fasta_name))
+    context.read_jobstore_file(job, fasta_id, os.path.join(work_dir, fasta_name))
 
     # download or create the fasta index which is required by hap.py
     if fasta_idx_id:
-        job.fileStore.readGlobalFile(fasta_idx_id, os.path.join(work_dir, fasta_name + '.fai'))
+        context.read_jobstore_file(job, fasta_idx_id, os.path.join(work_dir, fasta_name + '.fai'))
     else:
         context.runner.call(job, ['samtools', 'faidx', fasta_name], work_dir=work_dir)
 
     # download the bed regions
     bed_name = "bed_regions.bed" if bed_id else None
     if bed_id:
-        job.fileStore.readGlobalFile(bed_id, os.path.join(work_dir, bed_name))
+        context.read_jobstore_file(job, bed_id, os.path.join(work_dir, bed_name))
 
     # use out_name if specified, otherwise sample
     if sample and not out_name:
@@ -477,25 +477,25 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
     # download the vcf
     call_vcf_id, call_tbi_id = vcf_tbi_id_pair[0], vcf_tbi_id_pair[1]
     call_vcf_name = "{}calls.vcf.gz".format(out_name)
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
-    job.fileStore.readGlobalFile(vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[0], os.path.join(work_dir, call_vcf_name))
+    context.read_jobstore_file(job, vcf_tbi_id_pair[1], os.path.join(work_dir, call_vcf_name + '.tbi'))
 
     # and the truth vcf
     vcfeval_baseline_name = '{}truth.vcf.gz'.format(out_name)
-    job.fileStore.readGlobalFile(vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
-    job.fileStore.readGlobalFile(vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
+    context.read_jobstore_file(job, vcfeval_baseline_id, os.path.join(work_dir, vcfeval_baseline_name))
+    context.read_jobstore_file(job, vcfeval_baseline_tbi_id, os.path.join(work_dir, vcfeval_baseline_name + '.tbi'))
 
     # and the regions bed
     if bed_id:
         regions_bed_name = '{}regions.bed'.format(out_name)
-        job.fileStore.readGlobalFile(bed_id, os.path.join(work_dir, regions_bed_name))
+        context.read_jobstore_file(job, bed_id, os.path.join(work_dir, regions_bed_name))
     else:
         regions_bed_name = None
 
     # and the fasta
     if fasta_id:
         fasta_name = os.path.basename(fasta_path)
-        job.fileStore.readGlobalFile(fasta_id, os.path.join(work_dir, fasta_name))
+        context.read_jobstore_file(job, fasta_id, os.path.join(work_dir, fasta_name))
         # bcftools won't left-align indels over softmasked bases: make sure upper case        
         fa_upper_cmd = ['awk',  'BEGIN{FS=\" \"}{if(!/>/){print toupper($0)}else{print $1}}']
         if fasta_name.endswith('.gz'):


### PR DESCRIPTION
This is basically the [hack](https://github.com/ComparativeGenomicsToolkit/cactus/commit/2765e9679ce70aff905c446188d5ac24ebe4d2fc) that was suggested to fix this longstanding toil bug: https://github.com/DataBiosphere/toil/issues/1532

So now we go through `Context.read_jobstore_file(job, file,...)` instead of `job.fileStore.readGlobalFile(file,...)` whenever we want to download a file onto a worker.  Adding `cache=False` bypasses Toil's cache entirely as done in the above-referenced patch, and should be used whenever working with more than a handful of files within a single job (especially, ex, in the various merging jobs).  

Rationale for adding to Context class:  symmetry with existing "write" methods, as well as possibility to apply global overrides if needed down the road.

Hopefully fixes #680 

