### PR TITLE
Don't send unneeded promise to prune jobs

### DIFF
--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -215,7 +215,7 @@ def run_gcsa_prep(job, context, input_graph_ids,
     prune_ids = []
     for graph_i, input_graph_id in enumerate(input_graph_ids):
         gbwt_id = chrom_gbwt_ids[graph_i] if chrom_gbwt_ids else None
-        mapping_id = mapping_ids[-1] if mapping_ids else None        
+        mapping_id = mapping_ids[-1] if mapping_ids and gbwt_id else None
         prev_job = prune_jobs[-1] if prune_jobs and gbwt_id else prune_root_job
         if not skip_pruning:
             prune_job = prev_job.addFollowOnJobFn(run_gcsa_prune, context, graph_names[graph_i],
@@ -224,7 +224,7 @@ def run_gcsa_prep(job, context, input_graph_ids,
                                                   memory=context.config.prune_mem,
                                                   disk=context.config.prune_disk)
             prune_id = prune_job.rv(0)
-            # toggle between parallele/sequential based on if we're unfolding or now
+            # toggle between parallel/sequential based on if we're unfolding or now
             if gbwt_id:
                 prune_jobs.append(prune_job)
                 mapping_ids.append(prune_job.rv(1))


### PR DESCRIPTION
Resolves #687.   This case usually applies to decoy sequences where it'd be better just not to prune instead.  But the more general logic (when working) doesn't come at much extra cost and may be useful at some point. 