### PR TITLE
Add argument to activate inversion mode, point to new sveval docker

### DIFF
--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -192,7 +192,7 @@ bedtools-docker: 'quay.io/biocontainers/bedtools:2.27.0--1'
 bedops-docker: 'quay.io/biocontainers/bedops:2.4.35--0'
 
 # Docker image to use for sveval R package
-sveval-docker: 'jmonlong/sveval:version-1.1.1'
+sveval-docker: 'jmonlong/sveval:version-1.1.2'
 
 ##############################
 ### vg_construct Arguments ###

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -80,6 +80,8 @@ def vcfeval_parse_args(parser):
                         help="compare insertion sequence instead of their size only.")
     parser.add_argument("--del_min_rol", type=float, default=0.1,
                         help="the minimum reciprocal overlap when computing coverage on deletions")
+    parser.add_argument("--check_inv", action="store_true",
+                        help="try to identify inversions during SV evaluation.")
     parser.add_argument("--normalize", action="store_true",
                         help="normalize both VCFs before SV comparison with bcftools norm (requires --vcfeva_fasta)")
     parser.add_argument("--vcfeval_sample",
@@ -438,7 +440,7 @@ def run_happy(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeva
 
 def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfeval_baseline_tbi_id,
                 min_sv_len, max_sv_len, sv_overlap, sv_region_overlap, bed_id = None,
-                ins_ref_len=10, del_min_rol=.1, ins_seq_comp=False, 
+                ins_ref_len=10, del_min_rol=.1, ins_seq_comp=False, check_inv=False,
                 out_name = '', fasta_path = None, fasta_id = None, normalize = False):
     """ Run a overlap-based evaluation using the sveval R package (https://github.com/jmonlong/sveval)"""
 
@@ -532,6 +534,8 @@ def run_sv_eval(job, context, sample, vcf_tbi_id_pair, vcfeval_baseline_id, vcfe
         sveval_cmd += ', bed.regions.ol={}'.format(sv_region_overlap)
     if ins_seq_comp:
         sveval_cmd += ', ins.seq.comp=TRUE'
+    if check_inv:
+        sveval_cmd += ', check.inv=TRUE'
     sveval_cmd += ')'
     r_cmd_file = 'sveval.R'
     with open(os.path.join(work_dir, r_cmd_file), 'w') as r_file:
@@ -654,6 +658,7 @@ def vcfeval_main(context, options):
                                        ins_ref_len=options.ins_max_gap,
                                        del_min_rol=options.del_min_rol,
                                        ins_seq_comp=options.ins_seq_comp,
+                                       check_inv=options.check_inv,
                                        fasta_path=options.vcfeval_fasta,
                                        fasta_id=fasta_id,
                                        normalize=options.normalize, 


### PR DESCRIPTION
Inversion mode deactivated by default in sveval now. I added a parameter in toil-vg to switch it on if we need.

The new sveval docker image fixes the error when checking if large variants are inversions.