### PR TITLE
Option to call without chunking

### DIFF
--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -275,7 +275,7 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
     sort_vcf(job, context.runner, vcf_path, sorted_vcf_path)
 
     # Optional clip
-    if clip_info:
+    if clip_info and context.config.call_chunk_size != 0:
         left_clip = 0 if clip_info['chunk_i'] == 0 else context.config.overlap / 2
         right_clip = 0 if clip_info['chunk_i'] == clip_info['chunk_n'] - 1 else context.config.overlap / 2
         clip_path = os.path.join(work_dir, '{}_call_clip.vcf'.format(chunk_name))

--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -32,7 +32,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
-from toil_vg.vg_call import chunked_call_parse_args, run_all_calling, run_merge_vcf
+from toil_vg.vg_call import chunked_call_parse_args, run_all_calling, run_concat_vcfs
 from toil_vg.vg_vcfeval import vcfeval_parse_args, run_vcfeval, run_vcfeval_roc_plot, run_happy, run_sv_eval
 from toil_vg.context import Context, run_write_info_to_outstore
 from toil_vg.vg_construct import run_unzip_fasta, run_make_control_vcfs
@@ -186,7 +186,8 @@ def run_all_bam_caller(job, context, fasta_file_id, bam_file_id, bam_idx_id,
         fb_tbi_ids.append(fb_job.rv(1))
         fb_timers.append([fb_job.rv(2)])
 
-    merge_vcf_job = child_job.addFollowOnJobFn(run_merge_vcf, context, out_name, zip(fb_vcf_ids, fb_tbi_ids), fb_timers)
+    merge_vcf_job = child_job.addFollowOnJobFn(run_concat_vcfs, context, out_name, fb_vcf_ids, fb_tbi_ids,
+                                               write_to_outstore = True, call_timers_lists = fb_timers)
     return merge_vcf_job.rv()
     
 def run_bam_caller(job, context, fasta_file_id, bam_file_id, bam_idx_id,

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -247,7 +247,7 @@ msga-context: 50
 # Overlap option that is passed into make_chunks and call_chunk
 overlap: 2000
 
-# Chunk size
+# Chunk size (set to 0 to disable chunking)
 call-chunk-size: 2000000
 
 # Context expansion used for graph chunking
@@ -521,7 +521,7 @@ msga-context: 2000
 # Overlap option that is passed into make_chunks and call_chunk
 overlap: 100000
 
-# Chunk size
+# Chunk size (set to 0 to disable chunking)
 call-chunk-size: 2500000
 
 # Context expansion used for graph chunking


### PR DESCRIPTION
As discussed in #737, chunking along path ranges looks to be more trouble than it's worth on the cactus yeast graph.  
* It is brutally slow with the `recall-context` size of 2500
* The nodes are so small, that it's possible that insertions are still missed
* The resulting chunks (I think do to all the dangling ends) are very slow to compute snarls on (I measured 2 hours for one chunk, vs 6 minutes for the entire input graph)
So the idea is to get an option to disable chunking altogether and just run `vg call` on the input graph. 