### PR TITLE
Pack support for toil-vg call

### DIFF
--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -814,7 +814,7 @@ class VGCGLTest(TestCase):
                    '--call_vcf', os.path.join(self.local_outstore, 'HG00514.vcf.gz')])
         self._run(['toil', 'clean', self.jobStoreLocal])
                    
-        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.395)
+        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.38)
 
     def test_17_sim_small_pack_calling(self):
         ''' 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -858,7 +858,8 @@ class VGCGLTest(TestCase):
                    '--fasta', fa_path,
                    '--regions', 'chr21', 'chr22',
                    '--vcf', vcf_path,
-                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_path_gam_index', '--xg_index', '--gcsa_index'])
+                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_path_gam_index', '--xg_index',
+                   '--gcsa_index', '--snarls_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
@@ -887,6 +888,7 @@ class VGCGLTest(TestCase):
                    '--alt_path_gam', os.path.join(self.local_outstore, 'HGSVC_alts.gam'),
                    '--genotype_vcf', vcf_path,
                    '--call_chunk_cores', '8', '--pack',
+                   '--snarls', os.path.join(self.local_outstore, 'HGSVC.snarls'),
                    '--realTimeLogging', '--logInfo'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -814,7 +814,95 @@ class VGCGLTest(TestCase):
                    '--call_vcf', os.path.join(self.local_outstore, 'HG00514.vcf.gz')])
         self._run(['toil', 'clean', self.jobStoreLocal])
                    
-        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.395)           
+        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.395)
+
+    def test_17_sim_small_pack_calling(self):
+        ''' 
+        This is the same as test #1, but exercises --call_chunk_size 0
+        '''
+        self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
+        self.test_vg_graph = self._ci_input_path('small.vg')
+        self.baseline = self._ci_input_path('small.vcf.gz')
+        self.chrom_fa = self._ci_input_path('small.fa.gz')
+
+        self.base_command[self.base_command.index('--call_chunk_size') + 1] = '0'
+
+        self._run(self.base_command +
+                  [self.jobStoreLocal, '1',
+                   self.local_outstore, '--clean', 'never',
+                   '--fastq', self.sample_reads,
+                   '--graphs', self.test_vg_graph,
+                   '--chroms', 'x', '--vcfeval_baseline', self.baseline,
+                   '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy',
+                   '--pack', '--recall'])
+        self._run(['toil', 'clean', self.jobStoreLocal])
+
+        self._assertOutput('1', self.local_outstore, f1_threshold=0.95)
+
+    def test_18_pack_sv_genotyping(self):
+        '''
+        End to end SV genotyping on chr21 and chr22 of the HGSVC graph.  
+        We subset reads and variants to chr21:5000000-6000000 and chr22:10000000-11000000
+        and the fastas are subset to chr21:1-7000000 and chr22:1-12000000
+        Exactly like test 16, but using the new --pack option
+        '''
+
+        fa_path = self._ci_input_path('hg38_chr21_22.fa.gz')
+        vcf_path = self._ci_input_path('HGSVC_regions.vcf.gz')
+        gam_reads_path = self._ci_input_path('HGSVC_regions.gam')
+
+        self._run(['toil-vg', 'construct', self.jobStoreLocal, self.local_outstore,
+                   '--container', self.containerType,
+                   '--gcsa_index_cores', '8',
+                   '--clean', 'never',
+                   '--fasta', fa_path,
+                   '--regions', 'chr21', 'chr22',
+                   '--vcf', vcf_path,
+                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_path_gam_index', '--xg_index', '--gcsa_index'])
+        self._run(['toil', 'clean', self.jobStoreLocal])
+
+        self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
+                   os.path.join(self.local_outstore, 'HGSVC.xg'),
+                   os.path.join(self.local_outstore, 'HGSVC.gcsa'),
+                   self.local_outstore,
+                   '--container', self.containerType,
+                   '--clean', 'never',
+                   '--gam_input_reads', gam_reads_path,
+                   '--interleaved',
+                   '--alignment_cores', '8', 
+                   '--single_reads_chunk',
+                   '--realTimeLogging', '--logInfo'])
+        self._run(['toil', 'clean', self.jobStoreLocal])
+
+        self._run(['toil-vg', 'call', self.jobStoreLocal,
+                   os.path.join(self.local_outstore, 'HGSVC.xg'),
+                   'HG00514',
+                   self.local_outstore,
+                   '--container', self.containerType,
+                   '--clean', 'never',
+                   '--chroms', 'chr21', 'chr22',
+                   '--call_chunk_cores', '8',
+                   '--recall_context', '200',
+                   '--gams', os.path.join(self.local_outstore, 'HG00514_default.gam'),
+                   '--alt_path_gam', os.path.join(self.local_outstore, 'HGSVC_alts.gam'),
+                   '--genotype_vcf', vcf_path,
+                   '--call_chunk_cores', '8', '--pack',
+                   '--realTimeLogging', '--logInfo'])
+        self._run(['toil', 'clean', self.jobStoreLocal])
+
+        
+        self._run(['toil-vg', 'vcfeval', self.jobStoreLocal,
+                   self.local_outstore,
+                   '--sveval',
+                   '--vcfeval_baseline', vcf_path,
+                   '--vcfeval_sample', 'HG00514',
+                   '--normalize',
+                   '--vcfeval_fasta', fa_path,
+                   '--call_vcf', os.path.join(self.local_outstore, 'HG00514.vcf.gz')])
+        self._run(['toil', 'clean', self.jobStoreLocal])
+                   
+        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.38)
+        
         
     def _run(self, args):
         log.info('Running %r', args)

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -67,6 +67,8 @@ def chunked_call_parse_args(parser):
                         help="arguments to pass to vg genotype (wrapped in \"\")")
     parser.add_argument("--filter_opts", type=str,
                         help="argument to pass to vg filter (wrapped in \"\")")
+    parser.add_argument("--pack_opts", type=str,
+                        help="argument to pass to vg pack (wrapped in \"\")")
     parser.add_argument("--calling_cores", type=int,
                         help="number of threads during the variant calling step")
     parser.add_argument("--calling_mem", type=str,
@@ -259,6 +261,8 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
             pack_cmd = ['vg', 'pack', '-x', os.path.basename(xg_path), '-t', str(job.cores),
                         '-g', os.path.basename(aug_gam_path),
                         '-o', os.path.basename(support_path)]
+            if context.config.pack_opts:
+                pack_cmd += context.config.pack_opts
             try:
                 context.runner.call(job, pack_cmd, work_dir = work_dir)
             except Exception as e:

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -439,7 +439,7 @@ def run_all_calling2(job, context, xg_file_id, chr_gam_ids, chr_gam_idx_ids, chr
     assert len(chr_gam_ids) == len(chr_gam_idx_ids)
     # id ranges deactivates path chunking
     if id_ranges_id:
-        context.config.call_chunk_size = sys.maxint
+        context.config.call_chunk_size = (2 << 30) - 1
         context.config.overlap = 0
     for i in range(len(chr_gam_ids)):
         alignment_file_id = chr_gam_ids[i]

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -197,7 +197,7 @@ def run_vg_call(job, context, sample_name, vg_id, gam_id, xg_id = None,
         gam_filter_path = gam_path + '.filter'
         filter_command = None
         if filter_opts:
-            filter_command = ['vg', 'filter', os.path.basename(gam_path), '-t', '1'] + filter_opts
+            filter_command = ['vg', 'filter', os.path.basename(gam_path), '-t', str(context.config.calling_cores)] + filter_opts
             if defray:
                 filter_command += ['-x', os.path.basename(xg_path)]
             if genotype or pack_support:

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -439,7 +439,7 @@ def run_all_calling2(job, context, xg_file_id, chr_gam_ids, chr_gam_idx_ids, chr
     assert len(chr_gam_ids) == len(chr_gam_idx_ids)
     # id ranges deactivates path chunking
     if id_ranges_id:
-        context.config.call_chunk_size = 0
+        context.config.call_chunk_size = sys.maxint
         context.config.overlap = 0
     for i in range(len(chr_gam_ids)):
         alignment_file_id = chr_gam_ids[i]

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -884,6 +884,7 @@ def call_main(context, options):
             inputIDRangesID = None
             if options.id_ranges:
                 inputIDRangesID = importer.load(options.id_ranges)
+            inputSnarlsID = None
             if options.snarls:
                 inputSnarlsID = importer.load(options.snarls)
 

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -705,8 +705,8 @@ def run_chunking(job, context, xg_file_id, alignment_file_id, alignment_index_id
         chunk_path_base = os.path.splitext(os.path.join(work_dir, os.path.basename(toks[3].strip())))[0]
         gam_chunk_path = chunk_path_base + '.gam'
         vg_chunk_path = chunk_path_base + '.vg'
+        chunk_i = cur_path_offset[chunk_bed_chrom]        
         if not id_ranges_id:
-            chunk_i = cur_path_offset[chunk_bed_chrom]        
             gam_chunk_file_id = context.write_intermediate_file(job, gam_chunk_path)
             clipped_chunk_offset = chunk_i * context.config.call_chunk_size - chunk_i * context.config.overlap
             alt_gam_tag = "-1"

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -253,10 +253,13 @@ filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '99
 
 # Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
 # Also used with --genotype_vcf
-recall-filter-opts: ['-q', '15']
+recall-filter-opts: []
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
 augment-opts: ['-q', '10']
+
+# Options to pass to vg pack. (do not include any file names or -t/--threads)
+pack-opts: ['-Q', '15']
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: ['-e', '10']
@@ -532,10 +535,13 @@ filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '99
 
 # Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
 # Also used with --genotype_vcf
-recall-filter-opts: ['-q', '15']
+recall-filter-opts: []
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
 augment-opts: ['-q', '10']
+
+# Options to pass to vg pack. (do not include any file names or -t/--threads)
+pack-opts: ['-Q', '15']
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
 call-opts: ['-e', '10']
@@ -596,7 +602,7 @@ def apply_config_file_args(args):
     # turn --*_opts from strings to lists to be consistent with config file
     for x_opts in ['map_opts', 'call_opts', 'recall_opts', 'filter_opts', 'recall_filter_opts', 'genotype_opts',
                    'vcfeval_opts', 'sim_opts', 'bwa_opts', 'minimap2_opts', 'gcsa_opts', 'mpmap_opts',
-                   'augment_opts', 'prune_opts']:
+                   'augment_opts', 'pack_opts', 'prune_opts']:
         if x_opts in args.__dict__.keys() and type(args.__dict__[x_opts]) is str:
             args.__dict__[x_opts] = make_opts_list(args.__dict__[x_opts])
 

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -139,7 +139,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.15.0-208-gce79450f1-t311-run'
+vg-docker: 'quay.io/vgteam/vg:v1.16.0-137-ge54428488-t313-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'
@@ -253,7 +253,7 @@ filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '99
 
 # Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
 # Also used with --genotype_vcf
-recall-filter-opts: []
+recall-filter-opts: ['-q', '15']
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
 augment-opts: ['-q', '10']
@@ -418,7 +418,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.15.0-208-gce79450f1-t311-run'
+vg-docker: 'quay.io/vgteam/vg:v1.16.0-137-ge54428488-t313-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'
@@ -532,7 +532,7 @@ filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '99
 
 # Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
 # Also used with --genotype_vcf
-recall-filter-opts: []
+recall-filter-opts: ['-q', '15']
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
 augment-opts: ['-q', '10']

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -139,7 +139,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.16.0-137-ge54428488-t313-run'
+vg-docker: 'quay.io/vgteam/vg:v1.16.0-208-g421b5cf7a-t314-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'
@@ -421,7 +421,7 @@ container: """ + ("Docker" if test_docker() else "None") + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.16.0-137-ge54428488-t313-run'
+vg-docker: 'quay.io/vgteam/vg:v1.16.0-208-g421b5cf7a-t314-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -140,9 +140,6 @@ def pipeline_subparser(parser_run):
         help="Path to xg index (to use instead of generating new one)")    
     parser_run.add_argument("--gcsa_index", type=make_url,
         help="Path to GCSA index (to use instead of generating new one)")
-    parser_run.add_argument("--id_ranges", type=make_url,
-        help="Path to file with node id ranges for each chromosome in BED format.  If not"
-                            " supplied, will be generated from --graphs)")
 
     parser_run.add_argument("--graphs", nargs='+', type=make_url,
                         help="input graph(s). one per chromosome (separated by space)")
@@ -306,6 +303,7 @@ def run_pipeline_call(job, context, options, xg_file_id, id_ranges_file_id, chr_
     call_job = job.addChildJobFn(run_all_calling, context, xg_file_id, chr_gam_ids, None, chroms,
                                  options.vcf_offsets, options.sample_name,
                                  options.genotype, recall=options.recall,
+                                 pack_support = options.pack,
                                  cores=context.config.misc_cores, memory=context.config.misc_mem,
                                  disk=context.config.misc_disk)
     


### PR DESCRIPTION
`vg call` can now optionally get its support from `vg pack`.  This option is passed on to `toil-vg call` via `--pack`.  Also, the `--id_ranges` option can be used to do chromosome-level calling without any gam sorting or expensive chunking (vg chunk is still used to extract vg files from a whole-genome xg, for now, but this is relatively fast). 

The downside is that the toil-vg calling code has gotten too messy.  Supporting call/genotype/recall/pileup/pack/augment/sv-genotype/single-gam/chromosome-gam options and the combinations thereof is too much.   Should be able to simplify things soon by phasing out some of the old logic, hopefully.  It's handy in the meantime to have everything available for testing.    