### PR TITLE
Add Giraffe Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ kwargs = dict(
     author='UCSC Computational Genomics Lab',
     author_email='cgl-toil@googlegroups.com',
     url="https://github.com/BD2KGenomics/toil-vg",
+    python_requires='>=2.7,<3.0',
     install_requires=[x + y for x, y in required_versions.iteritems()],
     dependency_links=[],
     tests_require=['pytest==2.8.3', 'numpy', 'scipy'],

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -127,9 +127,9 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'sample',
-                   os.path.join(self.local_outstore, 'small.xg'),
-                   os.path.join(self.local_outstore, 'small.gcsa'),
                    self.local_outstore,
+                   '--xg_index', os.path.join(self.local_outstore, 'small.xg'),
+                   '--gcsa_index', os.path.join(self.local_outstore, 'small.gcsa'),
                    '--container', self.containerType,
                    '--clean', 'never',
                    '--fastq', self.sample_reads,
@@ -247,9 +247,9 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'sample',
-                   os.path.join(self.local_outstore, 'small.xg'),
-                   os.path.join(self.local_outstore, 'small.gcsa'),
                    self.local_outstore,
+                   '--xg_index', os.path.join(self.local_outstore, 'small.xg'),
+                   '--gcsa_index', os.path.join(self.local_outstore, 'small.gcsa'),
                    '--container', self.containerType,
                    '--clean', 'never',
                    '--gam_input_reads', os.path.join(self.local_outstore, 'sim.gam'),
@@ -781,9 +781,9 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
-                   os.path.join(self.local_outstore, 'HGSVC.xg'),
-                   os.path.join(self.local_outstore, 'HGSVC.gcsa'),
                    self.local_outstore,
+                   '--xg_index', os.path.join(self.local_outstore, 'HGSVC.xg'),
+                   '--gcsa_index', os.path.join(self.local_outstore, 'HGSVC.gcsa'),
                    '--container', self.containerType,
                    '--clean', 'never',
                    '--gam_input_reads', gam_reads_path,
@@ -868,9 +868,9 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
-                   os.path.join(self.local_outstore, 'HGSVC.xg'),
-                   os.path.join(self.local_outstore, 'HGSVC.gcsa'),
                    self.local_outstore,
+                   '--xg_index', os.path.join(self.local_outstore, 'HGSVC.xg'),
+                   '--gcsa_index', os.path.join(self.local_outstore, 'HGSVC.gcsa'),
                    '--container', self.containerType,
                    '--clean', 'never',
                    '--gam_input_reads', gam_reads_path,

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -122,7 +122,8 @@ class VGCGLTest(TestCase):
                    '--clean', 'never',
                    '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8',
-                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index'])
+                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--gcsa_index', 
+                   '--xg_index', '--snarls_index', '--id_ranges_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'sample',
@@ -232,7 +233,8 @@ class VGCGLTest(TestCase):
                    '--clean', 'never',
                    '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8',
-                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index'])
+                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--gcsa_index', 
+                   '--xg_index', '--snarls_index', '--id_ranges_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'sim', self.jobStoreLocal,
@@ -288,7 +290,8 @@ class VGCGLTest(TestCase):
                    '--clean', 'never',
                    '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8',
-                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index'])
+                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--gcsa_index', 
+                   '--xg_index', '--snarls_index', '--id_ranges_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'sim', self.jobStoreLocal,
@@ -626,7 +629,8 @@ class VGCGLTest(TestCase):
                    '--clean', 'never',
                    '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8',
-                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index'])
+                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--gcsa_index', 
+                   '--xg_index', '--snarls_index', '--id_ranges_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         # Simulate the reads
@@ -672,7 +676,8 @@ class VGCGLTest(TestCase):
                    '--clean', 'never',
                    '--graphs', self.test_vg_graph, '--chroms', 'x',
                    '--gcsa_index_cores', '8',
-                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--all_index'])
+                   '--realTimeLogging', '--logInfo', '--index_name', 'small', '--gcsa_index', 
+                   '--xg_index', '--snarls_index', '--id_ranges_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         # Simulate the reads

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -238,6 +238,9 @@ map-opts: []
 # Core arguments for vg multipath mapping (do not include file names or -t/--threads)
 mpmap-opts: ['--single-path-mode']
 
+# Core arguments for vg gaffe mapping (do not include file names or -t/--threads)
+gaffe-opts: []
+
 ########################
 ### vg_msga Arguments ###
 
@@ -530,6 +533,9 @@ map-opts: []
 # Core arguments for vg multipath mapping (do not include file names or -t/--threads)
 mpmap-opts: ['--single-path-mode']
 
+# Core arguments for vg gaffe mapping (do not include file names or -t/--threads)
+gaffe-opts: []
+
 ########################
 ### vg_msga Arguments ###
 
@@ -621,7 +627,7 @@ def apply_config_file_args(args):
 
     # turn --*_opts from strings to lists to be consistent with config file
     for x_opts in ['map_opts', 'call_opts', 'recall_opts', 'filter_opts', 'recall_filter_opts', 'genotype_opts',
-                   'vcfeval_opts', 'sim_opts', 'bwa_opts', 'minimap2_opts', 'gcsa_opts', 'mpmap_opts',
+                   'vcfeval_opts', 'sim_opts', 'bwa_opts', 'minimap2_opts', 'gcsa_opts', 'mpmap_opts', 'gaffe_opts',
                    'augment_opts', 'pack_opts', 'prune_opts']:
         if x_opts in args.__dict__.keys() and type(args.__dict__[x_opts]) is str:
             args.__dict__[x_opts] = make_opts_list(args.__dict__[x_opts])
@@ -645,7 +651,7 @@ def apply_config_file_args(args):
             config = conf.read()
                 
     # Parse config
-    parsed_config = {x.replace('-', '_'): y for x, y in yaml.load(config).iteritems()}
+    parsed_config = {x.replace('-', '_'): y for x, y in yaml.safe_load(config).iteritems()}
     if 'prune_opts_2' in parsed_config:
         raise RuntimeError('prune-opts-2 from config no longer supported')
     options = argparse.Namespace(**parsed_config)

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -77,6 +77,16 @@ snarl-index-cores: 1
 snarl-index-mem: '4G'
 snarl-index-disk: '2G'
 
+# Resources allotted for distance indexing.
+distance-index-cores: 1
+distance-index-mem: '4G'
+distance-index-disk: '2G'
+
+# Resources allotted for minimizer indexing.
+minimizer-index-cores: 8
+minimizer-index-mem: '4G'
+minimizer-index-disk: '2G'
+
 # Resources for BWA indexing.
 bwa-index-cores: 1
 bwa-index-mem: '4G'
@@ -358,6 +368,16 @@ gcsa-index-preemptable: True
 snarl-index-cores: 1
 snarl-index-mem: '200G'
 snarl-index-disk: '100G'
+
+# Resources allotted for distance indexing.
+distance-index-cores: 1
+distance-index-mem: '200G'
+distance-index-disk: '100G'
+
+# Resources allotted for minimizer indexing.
+minimizer-index-cores: 16
+minimizer-index-mem: '110G'
+minimizer-index-disk: '200G'
 
 # Resources for BWA indexing.
 bwa-index-cores: 1

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -682,7 +682,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                       max_node_size, alt_paths, flat_alts, handle_svs, regions,
                       merge_graphs = False, sort_ids = False, join_ids = False,
                       gcsa_index = False, xg_index = False, gbwt_index = False,
-                      id_ranges_index = False, snarls_index = False,
+                      id_ranges_index = False, snarls_index = False, trivial_snarls_index = False,
                       haplo_extraction_sample = None, haplotypes = [0,1], gbwt_prune = False,
                       normalize = False, validate = False, alt_regions_id = None,
                       alt_regions = [], alt_path_gam_index = False):
@@ -832,6 +832,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
         # some indexes should never get built for haplo/sample graphs
         skip_gcsa = not gcsa_index or name == 'haplo'
         skip_snarls = not snarls_index or haplo_extraction
+        skip_trivial_snarls = not trivial_snarls_index or haplo_extraction
         make_gbwt = gbwt_index and not haplo_extraction
         
         indexing_job = index_prev_job.addFollowOnJobFn(run_indexing, context, joined_vg_ids,
@@ -841,7 +842,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                                        node_mapping_id=mapping_id,
                                                        skip_xg=not xg_index, skip_gcsa=skip_gcsa,
                                                        skip_id_ranges=not id_ranges_index, skip_snarls=skip_snarls,
-                                                       skip_trivial_snarls=True,
+                                                       skip_trivial_snarls=skip_trivial_snarls,
                                                        make_gbwt=make_gbwt, gbwt_prune=gbwt_prune and make_gbwt,
                                                        gbwt_regions=gbwt_regions,
                                                        dont_restore_paths=alt_regions,
@@ -1783,6 +1784,7 @@ def construct_main(context, options):
                                      gbwt_index = options.gbwt_index or options.all_index,
                                      id_ranges_index = options.id_ranges_index or options.all_index,
                                      snarls_index = options.snarls_index or options.all_index,
+                                     trivial_snarls_index = options.trivial_snarls_index or options.all_index,
                                      haplo_extraction_sample = haplo_extraction_sample,
                                      gbwt_prune = options.gbwt_prune,
                                      normalize = options.normalize,

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -831,11 +831,11 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
         # So work out what indexes to build.
         wanted = set(wanted_indexes)
         if name == 'haplo':
-            wanted.remove('gcsa')
+            wanted.discard('gcsa')
         if haplo_extraction:
-            wanted.remove('snarls')
-            wanted.remove('trivial_snarls')
-            wanted.remove('gbwt')
+            wanted.discard('snarls')
+            wanted.discard('trivial_snarls')
+            wanted.discard('gbwt')
         
         indexing_job = index_prev_job.addFollowOnJobFn(run_indexing, context, joined_vg_ids,
                                                        joined_vg_names, output_name_base, chroms,

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -789,7 +789,8 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                     construct_job.addFollowOnJobFn(run_indexing, context, joined_vg_ids,
                                                    joined_vg_names, output_name_base, chroms, [], [], 
                                                    skip_xg=not xg_index, skip_gcsa=True,
-                                                   skip_id_ranges=True, skip_snarls=True)
+                                                   skip_id_ranges=True, skip_snarls=True,
+                                                   skip_trivial_snarls=True)
                 
                 index_prev_job = join_job
                 # In the indexing step below, we want to index our haplo-extracted sample graph
@@ -840,6 +841,7 @@ def run_construct_all(job, context, fasta_ids, fasta_names, vcf_inputs,
                                                        node_mapping_id=mapping_id,
                                                        skip_xg=not xg_index, skip_gcsa=skip_gcsa,
                                                        skip_id_ranges=not id_ranges_index, skip_snarls=skip_snarls,
+                                                       skip_trivial_snarls=True,
                                                        make_gbwt=make_gbwt, gbwt_prune=gbwt_prune and make_gbwt,
                                                        gbwt_regions=gbwt_regions,
                                                        dont_restore_paths=alt_regions,

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -67,7 +67,7 @@ def index_toggle_parse_args(parser):
     
     Safe to use in toil-vg construct without having to import any files.
     """
-    parser.add_argument("--gcsa_index", dest="indexes", action="append_const", const="gcsa",
+    parser.add_argument("--gcsa_index", dest="indexes", action="append_const", const="gcsa", default=[],
                         help="Make a gcsa index for each output graph")
     parser.add_argument("--xg_index",  dest="indexes", action="append_const", const="xg",
                         help="Make an xg index for each output graph")

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -132,17 +132,16 @@ def validate_index_options(options):
     if options.vcf_phasing:
         require(all([vcf.endswith('.vcf.gz') for vcf in options.vcf_phasing]),
                 'input phasing files must end with .vcf.gz')
-    if options.gbwt_index:
+    if 'gbwt' in options.indexes:
         require(options.vcf_phasing, 'generating a GBWT requires a VCF with phasing information')
     if options.gbwt_prune:
-        require(options.gbwt_index or options.gbwt_input, '--gbwt_index or --gbwt_input required for --gbwt_prune')
-        require(options.gcsa_index or options.all_index, '--gbwt_prune requires gbwt indexing')
-    require(not options.gbwt_index or not options.gbwt_input,
+        require(('gbwt' in options.indexes) or options.gbwt_input, '--gbwt_index or --gbwt_input required for --gbwt_prune')
+    require('gbwt' not in options.indexes or not options.gbwt_input,
             'only one of --gbwt_index and --gbwt_input can be used at a time')
     if options.gbwt_input:
         require(options.gbwt_prune == 'gbwt', '--gbwt_prune required with --gbwt_input')
     if options.vcf_phasing_regions:
-        require(options.gbwt_index, "cannot hint regions to GBWT indexer without building a GBWT index")
+        require('gbwt' in options.indexes, "cannot hint regions to GBWT indexer without building a GBWT index")
     
 def run_gcsa_prune(job, context, graph_name, input_graph_id, gbwt_id, mapping_id, remove_paths = []):
     """
@@ -1103,7 +1102,7 @@ def run_indexing(job, context, inputGraphFileIDs,
             # our first chromosome is effectively the whole genome (note that above we
             # detected this and put in index_name so it's saved right (don't care about chrom names))
             indexes['xg'] = indexes['chrom_xg'][0]
-        elif not skip_xg:
+        elif 'xg' in wanted:
             # Build an xg index for the whole genome. We need to have
             # access to all the per-chromosome GBWT files, if used, so we
             # can set the haplotype names and per-chromosome haplotype

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -1246,7 +1246,6 @@ def index_main(context, options):
                                      bwa_fasta_id=importer.resolve(inputBWAFastaID),
                                      wanted=set(options.indexes), gbwt_prune=options.gbwt_prune,
                                      gbwt_regions=options.vcf_phasing_regions,
-                                     alt_path_gam_index = options.alt_path_gam_index,
                                      cores=context.config.misc_cores,
                                      memory=context.config.misc_mem,
                                      disk=context.config.misc_disk)

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -615,7 +615,7 @@ def run_snarl_indexing(job, context, inputGraphFileIDs, graph_names, index_name=
     else:
         # Base case: single graph
    
-        RealtimeLogger.info("Starting snarl computation...")
+        RealtimeLogger.info("Starting snarl computation {} trivial snarls...".format('with' if include_trivial else 'without'))
         start_time = timeit.default_timer()
         
         # Define work directory for docker calls

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -651,7 +651,7 @@ def run_chunk_alignment(job, context, gam_input_reads, bam_input_reads, sample_n
         job.fileStore.readGlobalFile(indexes['id_ranges'], id_ranges_file)
 
         # Chunk the gam up by chromosome
-        gam_chunks = split_gam_into_chroms(job, work_dir, context, xg_file, id_ranges_file, output_file)
+        gam_chunks = split_gam_into_chroms(job, work_dir, context, index_files['xg'], id_ranges_file, output_file)
 
         # Write gam_chunks to store
         gam_chunk_ids = []

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -37,18 +37,32 @@ def map_subparser(parser):
     # General options
     
     parser.add_argument("sample_name", type=str,
-        help="sample name (ex NA12878)")
+                        help="sample name (ex NA12878)")
     
     parser.add_argument("out_store",
-        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
-    parser.add_argument("--id_ranges", type=str, default=None,
-        help="Path to file with node id ranges for each chromosome in BED format.")
+                        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
     parser.add_argument("--kmer_size", type=int,
-        help="size of kmers to use in gcsa-kmer mapping mode")
+                        help="size of kmers to use in gcsa-kmer mapping mode")
+    parser.add_argument("--id_ranges", type=make_url, default=None,
+                        help="Path to file with node id ranges for each chromosome in BED format.")
         
-    parser.add_argument("--mapper", default="map", choices=["map", "mpmap", "gaffe"],
-                    help="vg mapper to use")
-                    
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
+
+    # Add mapping options shared with mapeval and run
+    map_parse_args(parser)
+
+    # Add mapping options shared onyl with run
+    map_parse_index_args(parser)
+
+    # Add common docker options
+    add_container_tool_parse_args(parser)
+    
+def map_parse_index_args(parser):
+    """
+    Define map arguments shared with run but not mapeval
+    """
+    
     parser.add_argument("--xg_index", type=make_url,
                         help="Path to xg index")    
     parser.add_argument("--gcsa_index", type=make_url,
@@ -61,20 +75,13 @@ def map_subparser(parser):
                         help="Path to GBWT haplotype index")
     parser.add_argument("--snarls_index", type=make_url,
                         help="Path to snarls file")
-
-    # Add common options shared with everybody
-    add_common_vg_parse_args(parser)
-
-    # Add mapping options shared with mapeval
-    map_parse_args(parser)
-
-    # Add common docker options
-    add_container_tool_parse_args(parser)
-
+                        
+    parser.add_argument("--mapper", default="map", choices=["map", "mpmap", "gaffe"],
+                        help="vg mapper to use")
 
 def map_parse_args(parser, stand_alone = False):
     """
-    Define map arguments shared with mapeval
+    Define map arguments shared with mapeval and run
     """
     
     parser.add_argument("--fastq", nargs='+', type=make_url,
@@ -113,7 +120,7 @@ def validate_map_options(context, options):
     require(options.xg_index is not None, 'All mappers require --xg_index')
     
     if options.mapper == 'map' or options.mapper == 'mpmap':
-        require(options.gbwt_index, '--gbwt_index is required for map and mpmap')
+        require(options.gcsa_index, '--gcsa_index is required for map and mpmap')
     
     if options.mapper == 'gaffe':
         require(options.minimizer_index, '--minimizer_index is required for gaffe')

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -1053,8 +1053,11 @@ def run_map_eval_index(job, context, xg_file_ids, gcsa_file_ids, gbwt_file_ids, 
     index_ids = []
     if vg_file_ids:
         for vg_file_id in vg_file_ids:
+            # Index each VG. We can't produce a GBWT index because we have no
+            # VCF, but we can make the indexes needed for map and mpmap.
             index_job = job.addChildJobFn(run_indexing, context, [vg_file_id], ['default.vg'],
-                                          'index', ['default'], 
+                                          'index', ['default'],
+                                          wanted=set(['xg', 'gcsa', 'id_ranges', 'snarls']),
                                           cores=context.config.misc_cores, memory=context.config.misc_mem,
                                           disk=context.config.misc_disk)
             index_ids.append(index_job.rv())

--- a/src/toil_vg/vg_mapeval.py
+++ b/src/toil_vg/vg_mapeval.py
@@ -250,6 +250,8 @@ def validate_options(options):
     if options.vg_graphs:
         require(not options.gams and not options.index_bases,
                 'if --vg-graphs specified, --gams and --index-bases must not be used')
+        require('gaffe' not in options.mappers,
+                '--vg-graphs cannot be used with gaffe because gaffe needs a GBWT')
 
     # must have a name for each graph/index/gam
     if options.gams:

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -153,6 +153,7 @@ def pipeline_subparser(parser_run):
 
     # add common mapping options shared with vg_map
     map_parse_args(parser_run)
+    map_parse_index_args(parser_run)
     
     # Add common calling options shared with vg_call
     chunked_call_parse_args(parser_run)
@@ -181,6 +182,10 @@ def validate_pipeline_options(options):
             '--interleaved cannot be used when > 1 fastq given')
     require(sum(map(lambda x : 1 if x else 0, [options.fastq, options.gam_input_reads, options.bam_input_reads])) == 1,
             'reads must be speficied with either --fastq or --gam_input_reads or --bam_input_reads')
+            
+    # TODO: to support gaffe here we need to add code to load its indexes from
+    # the options and thread them through our indexing stage.
+    require(options.mapper != 'gaffe', 'gaffe mapper is not yet supported by toil-vg run')
 
     
 # Below are the top level jobs of the toil_vg pipeline.  They
@@ -278,7 +283,7 @@ def run_pipeline_map(job, context, options, indexes, fastq_chunk_ids,
 
     chr_gam_ids = job.addChildJobFn(run_whole_alignment, context,
                                     options.fastq, options.gam_input_reads, options.bam_input_reads,
-                                    options.sample_name, options.interleaved, options.multipath,
+                                    options.sample_name, options.interleaved, options.mapper,
                                     indexes, fastq_chunk_ids,
                                     bam_output=options.bam_output, surject=options.surject,
                                     cores=context.config.misc_cores, memory=context.config.misc_mem,

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -136,10 +136,6 @@ def pipeline_subparser(parser_run):
         help="sample name (ex NA12878)")
     parser_run.add_argument("out_store",
         help="output store.  All output written here. Path specified using same syntax as toil jobStore")
-    parser_run.add_argument("--xg_index", type=make_url,
-        help="Path to xg index (to use instead of generating new one)")    
-    parser_run.add_argument("--gcsa_index", type=make_url,
-        help="Path to GCSA index (to use instead of generating new one)")
 
     parser_run.add_argument("--graphs", nargs='+', type=make_url,
                         help="input graph(s). one per chromosome (separated by space)")

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -223,7 +223,7 @@ def run_pipeline_index(job, context, options, inputGraphFileIDs, inputReadsFileI
                                   vcf_phasing_file_ids = inputPhasingVCFFileIDs,
                                   tbi_phasing_file_ids = inputPhasingTBIFileIDs,
                                   skip_xg=skip_xg, skip_gcsa=skip_gcsa, skip_id_ranges=skip_ranges, skip_snarls=True,
-                                  make_gbwt=False,
+                                  skip_trivial_snarls=True, make_gbwt=False,
                                   cores=context.config.misc_cores, memory=context.config.misc_mem,
                                   disk=context.config.misc_disk)
                                   

--- a/version.py
+++ b/version.py
@@ -17,6 +17,7 @@ version = '1.5.0a2'
 required_versions = {'pyyaml': '>=3.11',
                      'tsv': '==1.2',
                      'scikit-learn': '==0.18.2',
-                     'pyvcf': '==0.6.8'}
+                     'pyvcf': '==0.6.8',
+                     'futures': '==3.2.0'}
 
 dependency_links = []

--- a/version.py
+++ b/version.py
@@ -14,7 +14,7 @@
 
 version = '1.5.0a2'
 
-required_versions = {'pyyaml': '>=3.11',
+required_versions = {'pyyaml': '>=5.1',
                      'tsv': '==1.2',
                      'scikit-learn': '==0.18.2',
                      'pyvcf': '==0.6.8',

--- a/version.py
+++ b/version.py
@@ -18,6 +18,6 @@ required_versions = {'pyyaml': '>=3.11',
                      'tsv': '==1.2',
                      'scikit-learn': '==0.18.2',
                      'pyvcf': '==0.6.8',
-                     'futures': '==3.2.0'}
+                     'futures': '==3.1.1'}
 
 dependency_links = []


### PR DESCRIPTION
This adds the Giraffe mapper and its required indexes to toil-vg.

Now you can ask for `--distance_index` and `--minimizer_index` with `toil-vg construct` or `toil-vg index`, and you can use `--mappers gaffe` to ask for Giraffe in `toil-vg mapeval`. The old `--multipath` and `--multipath-only` options still work, but now you should use `--mappers [gaffe] [mpmap] [map]` instead.