### PR TITLE
WIP: Rewrite toil-vg call

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ toil-vg can run vg, along with some other tools, via [Docker](http://www.docker.
 
 ## Configuration
 
-A configuration file can be used as an alternative to most command line options.  A default configuration file can be generated using
+A configuration file can be used as an alternative to some command line options, as well as to tune Toil job resources.  A default configuration file can be generated using
 
     toil-vg generate-config > config.yaml
 

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -337,6 +337,7 @@ class VGCGLTest(TestCase):
                    '--sample', '1',
                    '--calling_cores', '2',
                    '--call',
+                   '--min_mapq', '5', '--min_baseq', '5', '--min_augment_coverage', '2',
                    '--freebayes', '--force_outstore',
                    '--bams', os.path.join(self.local_outstore, 'bwa-mem.bam'),
                    os.path.join(self.local_outstore, 'bwa-mem-pe.bam'),

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -68,12 +68,11 @@ class VGCGLTest(TestCase):
         self.base_command = ['toil-vg', 'run',
                              '--container', self.containerType,
                              '--realTimeLogging', '--logInfo', '--reads_per_chunk', '8000',
-                             '--call_chunk_size', '20000',
                              '--gcsa_index_cores', '8',
                              '--alignment_cores', '4',
                              '--calling_cores', '4', '--vcfeval_cores', '4',
                              '--vcfeval_opts', ' --ref-overlap',
-                             '--call_opts', '-E 0']
+                             '--min_mapq', '15', '--min_baseq', '10']
         
         # default output store
         self.local_outstore = os.path.join(self.workdir, 'toilvg-jenkinstest-outstore-{}'.format(uuid4()))
@@ -138,18 +137,19 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
         
         self._run(['toil-vg', 'call', self.jobStoreLocal,
-                   os.path.join(self.local_outstore, 'small.xg'), 'sample',
+                   '--graph', os.path.join(self.local_outstore, 'small.xg'),
+                   '--sample', 'sample',
                    self.local_outstore, 
                    '--container', self.containerType,
                    '--clean', 'never',
-                   '--gams', os.path.join(self.local_outstore, 'sample_default.gam'), 
-                   '--chroms', 'x', '--call_chunk_size', '20000', '--calling_cores', '4',
+                   '--gam', os.path.join(self.local_outstore, 'sample_default.gam'), 
+                   '--ref_paths', 'x', '--calling_cores', '4',
                    '--realTimeLogging', '--logInfo'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'vcfeval', self.jobStoreLocal,
                    '--container', self.containerType,
-                   '--call_vcf', os.path.join(self.local_outstore, 'sample.vcf.gz'),
+                   '--call_vcf', os.path.join(self.local_outstore, 'small_sample.vcf.gz'),
                    '--vcfeval_baseline', self.baseline,
                    '--vcfeval_fasta', self.chrom_fa, self.local_outstore,
                    '--clean', 'never',
@@ -324,7 +324,7 @@ class VGCGLTest(TestCase):
                    self.local_outstore,
                    '--container', self.containerType,
                    '--clean', 'never',
-                   '--chroms', 'x',
+                   '--ref_paths', 'x',
                    '--xg_paths', os.path.join(self.local_outstore, 'small.xg'),
                    os.path.join(self.local_outstore, 'small.xg'),
                    '--gams', os.path.join(self.local_outstore, 'aligned-vg_default.gam'),
@@ -334,7 +334,7 @@ class VGCGLTest(TestCase):
                    '--vcfeval_fasta', self.chrom_fa_nz,
                    '--vcfeval_baseline', self.baseline,
                    '--vcfeval_bed_regions', self.bed_regions,
-                   '--sample_name', '1',
+                   '--sample', '1',
                    '--calling_cores', '2',
                    '--call',
                    '--freebayes', '--force_outstore',
@@ -426,27 +426,22 @@ class VGCGLTest(TestCase):
         ''' Test running vg call on one gam that contains multiple paths
         '''
 
-        self.sample_gam = os.path.join(self.local_outstore, 'NA12877_both.gam')
-        with open(os.path.join(self.local_outstore, 'NA12877_13.gam')) as gam1, \
-             open(os.path.join(self.local_outstore, 'NA12877_17.gam')) as gam2, \
-             open(self.sample_gam, 'w') as merged_gam:
-            shutil.copyfileobj(gam1, merged_gam)
-            shutil.copyfileobj(gam2, merged_gam)
-             
+        self.sample_gam = os.path.join(self.local_outstore, 'NA12877_default.gam')             
         self.xg_index = os.path.join(self.local_outstore, 'genome.xg')        
 
         outstore = self.local_outstore + '.2'
         self._run(['toil-vg', 'call', self.jobStoreLocal,
                    '--container', self.containerType,
                    '--clean', 'never',
-                   self.xg_index, 'NA12877', outstore, '--gams', self.sample_gam,
-                   '--chroms', '17', '13', '--vcf_offsets', '43044293', '32314860',
-                   '--call_chunk_size', '23000', '--calling_cores', '4',
-                   '--realTimeLogging', '--realTimeStderr', '--logInfo', '--call_opts', '-E 0'])
+                   '--graph', self.xg_index, '--sample', 'NA12877', outstore, '--gam', self.sample_gam,
+                   '--ref_paths', '17', '13', '--vcf_offsets', '43044293', '32314860',
+                   '--calling_cores', '4',
+                   '--min_mapq', '15', '--min_baseq', '10',
+                   '--realTimeLogging', '--realTimeStderr', '--logInfo'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'vcfeval', self.jobStoreLocal, '--clean', 'never',
-                   '--call_vcf', os.path.join(outstore, 'NA12877.vcf.gz'),
+                   '--call_vcf', os.path.join(outstore, 'genome-aug_NA12877.vcf.gz'),
                    '--vcfeval_baseline', self.baseline,
                    '--vcfeval_fasta', self.chrom_fa, outstore,
                    '--realTimeLogging', '--realTimeStderr', '--logInfo',
@@ -528,8 +523,8 @@ class VGCGLTest(TestCase):
         # Todo: better correctness checks (maybe compare to hand-generated data?
         prev_vg_size = None
         prev_vcf_size = None
-        for ext in ['', '_filter', '_minus_HG00096', '_HG00096_sample', '_HG00096_haplo', '_minaf_0.6']:
-            if ext and ext not in ['_HG00096_haplo', '_minaf_0.6', '_HG00096_sample']:
+        for ext in ['', '_filter', '_minus_HG00096', '_HG00096_sample_withref', '_HG00096_haplo', '_minaf_0.6']:
+            if ext and ext not in ['_HG00096_haplo', '_minaf_0.6', '_HG00096_sample_withref']:
                 vcf_file = os.path.join(self.local_outstore, '{}-vcfs'.format(out_name), '1kg_hg38-BRCA1{}.vcf.gz'.format(ext))
 
                 assert os.path.isfile(vcf_file)
@@ -540,7 +535,7 @@ class VGCGLTest(TestCase):
                 with gzip.open(vcf_file) as vf:
                     vcf_size = len([line for line in vf])
                 if prev_vcf_size is not None:
-                    assert vcf_size < prev_vcf_size
+                    assert vcf_size <= prev_vcf_size
                 prev_vcf_size = vcf_size
 
             vg_file = os.path.join(self.local_outstore, '{}{}.vg'.format(out_name, ext))
@@ -549,29 +544,8 @@ class VGCGLTest(TestCase):
 
             vg_size = os.path.getsize(vg_file)
             if prev_vg_size is not None:
-                assert vg_size < prev_vg_size
+                assert vg_size <= prev_vg_size
             prev_vg_size = vg_size
-
-    def test_10_sim_small_genotype(self):
-        ''' 
-        This is the same as test #1, but exercises --force_outstore and --genotype
-        '''
-        self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
-        self.test_vg_graph = self._ci_input_path('small.vg')
-        self.baseline = self._ci_input_path('small.vcf.gz')
-        self.chrom_fa = self._ci_input_path('small.fa.gz')
-
-        self._run(self.base_command +
-                  [self.jobStoreLocal, '1',
-                   self.local_outstore, '--clean', 'never',
-                   '--fastq', self.sample_reads,
-                   '--graphs', self.test_vg_graph,
-                   '--chroms', 'x', '--vcfeval_baseline', self.baseline,
-                   '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy',
-                   '--genotype', '--genotype_opts', ' -Q -A'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        self._assertOutput('1', self.local_outstore, f1_threshold=0.95)
 
     def test_11_gbwt(self):
         '''
@@ -737,28 +711,6 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
 
-    def test_15_sim_small_no_call_chunking(self):
-        ''' 
-        This is the same as test #1, but exercises --call_chunk_size 0
-        '''
-        self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
-        self.test_vg_graph = self._ci_input_path('small.vg')
-        self.baseline = self._ci_input_path('small.vcf.gz')
-        self.chrom_fa = self._ci_input_path('small.fa.gz')
-
-        self.base_command[self.base_command.index('--call_chunk_size') + 1] = '0'
-
-        self._run(self.base_command +
-                  [self.jobStoreLocal, '1',
-                   self.local_outstore, '--clean', 'never',
-                   '--fastq', self.sample_reads,
-                   '--graphs', self.test_vg_graph,
-                   '--chroms', 'x', '--vcfeval_baseline', self.baseline,
-                   '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        self._assertOutput('1', self.local_outstore, f1_threshold=0.95)
-
     def test_16_sv_genotyping(self):
         '''
         End to end SV genotyping on chr21 and chr22 of the HGSVC graph.  
@@ -772,12 +724,12 @@ class VGCGLTest(TestCase):
 
         self._run(['toil-vg', 'construct', self.jobStoreLocal, self.local_outstore,
                    '--container', self.containerType,
-                   '--gcsa_index_cores', '8',
+                   '--gcsa_index_cores', '8', '--realTimeLogging',
                    '--clean', 'never',
                    '--fasta', fa_path,
                    '--regions', 'chr21', 'chr22',
                    '--vcf', vcf_path,
-                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_path_gam_index', '--xg_index', '--gcsa_index'])
+                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_paths', '--xg_index', '--xg_alts', '--gcsa_index'])
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
@@ -794,16 +746,13 @@ class VGCGLTest(TestCase):
         self._run(['toil', 'clean', self.jobStoreLocal])
 
         self._run(['toil-vg', 'call', self.jobStoreLocal,
-                   os.path.join(self.local_outstore, 'HGSVC.xg'),
-                   'HG00514',
+                   '--graph', os.path.join(self.local_outstore, 'HGSVC.xg'),
+                   '--sample', 'HG00514', '--realTimeLogging', 
                    self.local_outstore,
                    '--container', self.containerType,
                    '--clean', 'never',
-                   '--chroms', 'chr21', 'chr22',
-                   '--call_chunk_cores', '8',
-                   '--recall_context', '200',
-                   '--gams', os.path.join(self.local_outstore, 'HG00514_default.gam'),
-                   '--alt_path_gam', os.path.join(self.local_outstore, 'HGSVC_alts.gam'),
+                   '--ref_paths', 'chr21', 'chr22',
+                   '--gam', os.path.join(self.local_outstore, 'HG00514_default.gam'),
                    '--genotype_vcf', vcf_path,
                    '--call_chunk_cores', '8'])
         self._run(['toil', 'clean', self.jobStoreLocal])
@@ -816,100 +765,10 @@ class VGCGLTest(TestCase):
                    '--vcfeval_sample', 'HG00514',
                    '--normalize',
                    '--vcfeval_fasta', fa_path,
-                   '--call_vcf', os.path.join(self.local_outstore, 'HG00514.vcf.gz')])
+                   '--call_vcf', os.path.join(self.local_outstore, 'HGSVC_HG00514.vcf.gz')])
         self._run(['toil', 'clean', self.jobStoreLocal])
                    
-        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.31)
-
-    def test_17_sim_small_pack_calling(self):
-        ''' 
-        This is the same as test #1, but exercises --call_chunk_size 0
-        '''
-        self.sample_reads = self._ci_input_path('small_sim_reads.fq.gz')
-        self.test_vg_graph = self._ci_input_path('small.vg')
-        self.baseline = self._ci_input_path('small.vcf.gz')
-        self.chrom_fa = self._ci_input_path('small.fa.gz')
-
-        self.base_command[self.base_command.index('--call_chunk_size') + 1] = '0'
-
-        self._run(self.base_command +
-                  [self.jobStoreLocal, '1',
-                   self.local_outstore, '--clean', 'never',
-                   '--fastq', self.sample_reads,
-                   '--graphs', self.test_vg_graph,
-                   '--chroms', 'x', '--vcfeval_baseline', self.baseline,
-                   '--vcfeval_fasta', self.chrom_fa, '--vcfeval_opts', ' --squash-ploidy',
-                   '--pack', '--recall'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        self._assertOutput('1', self.local_outstore, f1_threshold=0.95)
-
-    def test_18_pack_sv_genotyping(self):
-        '''
-        End to end SV genotyping on chr21 and chr22 of the HGSVC graph.  
-        We subset reads and variants to chr21:5000000-6000000 and chr22:10000000-11000000
-        and the fastas are subset to chr21:1-7000000 and chr22:1-12000000
-        Exactly like test 16, but using the new --pack option
-        '''
-
-        fa_path = self._ci_input_path('hg38_chr21_22.fa.gz')
-        vcf_path = self._ci_input_path('HGSVC_regions.vcf.gz')
-        gam_reads_path = self._ci_input_path('HGSVC_regions.gam')
-
-        self._run(['toil-vg', 'construct', self.jobStoreLocal, self.local_outstore,
-                   '--container', self.containerType,
-                   '--gcsa_index_cores', '8',
-                   '--clean', 'never',
-                   '--fasta', fa_path,
-                   '--regions', 'chr21', 'chr22',
-                   '--vcf', vcf_path,
-                   '--out_name', 'HGSVC', '--pangenome', '--flat_alts', '--alt_path_gam_index', '--xg_index',
-                   '--gcsa_index', '--snarls_index'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        self._run(['toil-vg', 'map', self.jobStoreLocal, 'HG00514',
-                   self.local_outstore,
-                   '--xg_index', os.path.join(self.local_outstore, 'HGSVC.xg'),
-                   '--gcsa_index', os.path.join(self.local_outstore, 'HGSVC.gcsa'),
-                   '--container', self.containerType,
-                   '--clean', 'never',
-                   '--gam_input_reads', gam_reads_path,
-                   '--interleaved',
-                   '--alignment_cores', '8', 
-                   '--single_reads_chunk',
-                   '--realTimeLogging', '--logInfo'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        self._run(['toil-vg', 'call', self.jobStoreLocal,
-                   os.path.join(self.local_outstore, 'HGSVC.xg'),
-                   'HG00514',
-                   self.local_outstore,
-                   '--container', self.containerType,
-                   '--clean', 'never',
-                   '--chroms', 'chr21', 'chr22',
-                   '--call_chunk_cores', '8',
-                   '--recall_context', '200',
-                   '--gams', os.path.join(self.local_outstore, 'HG00514_default.gam'),
-                   '--alt_path_gam', os.path.join(self.local_outstore, 'HGSVC_alts.gam'),
-                   '--genotype_vcf', vcf_path,
-                   '--call_chunk_cores', '8', '--pack',
-                   '--snarls', os.path.join(self.local_outstore, 'HGSVC.snarls'),
-                   '--realTimeLogging', '--logInfo'])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-
-        
-        self._run(['toil-vg', 'vcfeval', self.jobStoreLocal,
-                   self.local_outstore,
-                   '--sveval',
-                   '--vcfeval_baseline', vcf_path,
-                   '--vcfeval_sample', 'HG00514',
-                   '--normalize',
-                   '--vcfeval_fasta', fa_path,
-                   '--call_vcf', os.path.join(self.local_outstore, 'HG00514.vcf.gz')])
-        self._run(['toil', 'clean', self.jobStoreLocal])
-                   
-        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.31)
-        
+        self._assertSVEvalOutput(self.local_outstore, f1_threshold=0.31)        
         
     def _run(self, args):
         log.info('Running %r', args)

--- a/src/toil_vg/vg_augment.py
+++ b/src/toil_vg/vg_augment.py
@@ -71,6 +71,10 @@ def augment_parse_args(parser, stand_alone = False):
                         help="ignore reads with MAPQ less than this")
     parser.add_argument("--min_baseq", type=int,
                         help="ignore edits with minimum average base quality less than this")
+    parser.add_argument("--augment_cores", type=int,
+                        help="number of threads during augmentation")
+    parser.add_argument("--augment_mem", type=str,
+                        help="memory alotment during augmentation")
 
 def run_chunked_augmenting(job, context,
                            graph_id,

--- a/src/toil_vg/vg_augment.py
+++ b/src/toil_vg/vg_augment.py
@@ -106,9 +106,9 @@ def run_chunked_augmenting(job, context,
                                                 output_format=output_format,
                                                 gam_id=gam_id,
                                                 to_outstore=False,
-                                                cores=context.config.call_chunk_cores,
-                                                memory=context.config.call_chunk_mem,
-                                                disk=context.config.call_chunk_disk)
+                                                cores=context.config.chunk_cores,
+                                                memory=context.config.chunk_mem,
+                                                disk=context.config.chunk_disk)
             batch_input = chunk_job.rv()
 
             # recurse on chunks
@@ -151,9 +151,9 @@ def run_chunked_augmenting(job, context,
                                         min_mapq=min_mapq,
                                         min_baseq=min_baseq,
                                         to_outstore=to_outstore,
-                                        cores=context.config.call_chunk_cores,
-                                        memory=context.config.call_chunk_mem,
-                                        disk=context.config.call_chunk_disk)
+                                        cores=context.config.augment_cores,
+                                        memory=context.config.augment_mem,
+                                        disk=context.config.augment_disk)
         
         augment_results.append((chunk_name, augment_job.rv()))
 
@@ -201,6 +201,10 @@ def run_augmenting(job, context,
         augment_cmd += ['-Q', str(min_mapq)]
     if min_baseq is not None:
         augment_cmd += ['-q', str(min_baseq)]
+    if context.config.augment_opts:
+        augment_cmd += context.config.augment_opts
+    # always support subgraphs
+    augment_cmd += ['-s']
 
     # run the command
     try:

--- a/src/toil_vg/vg_augment.py
+++ b/src/toil_vg/vg_augment.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python2.7
+"""
+vg_augment.py: augment a vg graph to include variation from a GAM alignment
+
+"""
+from __future__ import print_function
+import argparse, sys, os, os.path, errno, random, subprocess, shutil, itertools, glob, tarfile
+import doctest, re, json, collections, time, timeit
+import logging, logging.handlers, SocketServer, struct, socket, threading
+import string
+import urlparse
+import getpass
+import pdb
+import gzip
+import logging
+
+from math import ceil
+from subprocess import Popen, PIPE
+
+from toil.common import Toil
+from toil.job import Job
+from toil.realtimeLogger import RealtimeLogger
+from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
+from toil_vg.vg_chunk import *
+
+logger = logging.getLogger(__name__)
+
+def augment_subparser(parser):
+    """
+    Create a subparser for augmenting.  Should pass in results of subparsers.add_parser()
+    """
+
+    # Add the Toil options so the job store is the first argument
+    Job.Runner.addToilOptions(parser)
+    
+    # General options
+    
+    parser.add_argument("out_store",
+                        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
+        
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
+
+    # Add augment options
+    augment_parse_args(parser)
+
+    # Add common chunking options shared with vg_chunk
+    chunk_parse_args(parser)
+
+    # Add common docker options
+    add_container_tool_parse_args(parser)
+
+    # local main options
+    parser.add_argument("--gam", type=make_url, required=True,
+                        help="GAM to augment")
+    parser.add_argument("--graph", type=make_url, required=True,
+                        help="graph to augment")
+
+def augment_parse_args(parser, stand_alone = False):
+    """
+    Define map arguments shared with mapeval and run
+    """
+    parser.add_argument("--augment_gam", action="store_true",
+                        help="produce and augmented GAM")    
+    parser.add_argument("--min_coverage", type=int, 
+                        help="minimum coverage for breakpoint to be applied")
+    parser.add_argument("--expected_coverage", type=int,
+                        help="expected coverage.  only affects memory usage.  use if coverage >> 100")
+    parser.add_argument("--min_mapq", type=int,
+                        help="ignore reads with MAPQ less than this")
+    parser.add_argument("--min_baseq", type=int,
+                        help="ignore edits with minimum average base quality less than this")
+
+def run_chunked_augmenting(job, context,
+                           graph_id,
+                           graph_basename,
+                           gam_id,
+                           gam_basename,
+                           all_path_components=False,
+                           chunk_paths=[],
+                           connected_component_chunking=False,
+                           output_format=None,
+                           augment_gam=False,
+                           min_coverage=None,
+                           expected_coverage=None,
+                           min_mapq=None, 
+                           min_baseq=None,
+                           to_outstore=False):
+    """
+    Run a chunking job (if desired), then augment the results
+    """
+
+    if all_path_components or connected_component_chunking or len(chunk_paths) > 1:
+        child_job = Job()
+        job.addChild(child_job)
+
+        chunk_job = child_job.addChildJobFn(run_chunking, context,
+                                            graph_id=graph_id,
+                                            graph_basename=graph_basename,
+                                            chunk_paths=chunk_paths,
+                                            connected_component_chunking=connected_component_chunking,
+                                            output_format=output_format,
+                                            gam_id=gam_id,
+                                            to_outstore=False,
+                                            cores=context.config.call_chunk_cores,
+                                            memory=context.config.call_chunk_mem,
+                                            disk=context.config.call_chunk_disk)
+        augment_batch_job = child_job.addFollowOnJobFn(run_batch_augmenting, context,
+                                                       data_map=chunk_job.rv(),
+                                                       augment_gam=augment_gam,
+                                                       min_coverage=min_coverage,
+                                                       expected_coverage=expected_coverage,
+                                                       min_mapq=min_mapq,
+                                                       min_baseq=min_baseq,
+                                                       to_outstore=to_outstore)
+        return augment_batch_job.rv()
+    else:
+        augment_job = job.addChildJobFn(run_augmenting, context,
+                                        graph_id=graph_id,
+                                        graph_basename=graph_basename,
+                                        gam_id=gam_id,
+                                        gam_basename=gam_basename,
+                                        augment_gam=augment_gam,
+                                        min_coverage=min_coverage,
+                                        expected_coverage=expected_coverage,
+                                        min_mapq=min_mapq,
+                                        min_baseq=min_baseq,
+                                        to_outstore=to_outstore,
+                                        cores=context.config.call_chunk_cores,
+                                        memory=context.config.call_chunk_mem,
+                                        disk=context.config.call_chunk_disk)
+        return [('all', augment_job.rv())]
+
+def run_batch_augmenting(job, context,
+                         data_map,
+                         augment_gam=False,
+                         min_coverage=None,
+                         expected_coverage=None,
+                         min_mapq=None,
+                         min_baseq=None,
+                         to_outstore=False):
+    """
+    Spawn a bunch of child augmenting jobs, using the return value of run_chunking
+    as input.
+    """
+    augment_results = []
+    for chunk_name, chunk_results in data_map.items():
+        augment_job = job.addChildJobFn(run_augmenting, context,
+                                        graph_id=chunk_results[0],
+                                        graph_basename=chunk_results[1],
+                                        gam_id=chunk_results[2],
+                                        gam_basename=chunk_results[3],
+                                        augment_gam=augment_gam,
+                                        min_coverage=min_coverage,
+                                        expected_coverage=expected_coverage,
+                                        min_mapq=min_mapq,
+                                        min_baseq=min_baseq,
+                                        to_outstore=to_outstore,
+                                        cores=context.config.call_chunk_cores,
+                                        memory=context.config.call_chunk_mem,
+                                        disk=context.config.call_chunk_disk)
+        
+        augment_results.append((chunk_name, augment_job.rv()))
+
+    return augment_results
+
+def run_augmenting(job, context,
+                  graph_id,
+                  graph_basename,
+                  gam_id,
+                  gam_basename,
+                  augment_gam=False,
+                  min_coverage=None,
+                  expected_coverage=None,
+                  min_mapq=None,
+                  min_baseq=None,
+                  to_outstore=False):
+    """
+    Augment the graph (and gam if wanted)
+    """
+
+    work_dir = job.fileStore.getLocalTempDir()
+
+    # Read our input files from the store
+    graph_path = os.path.join(work_dir, graph_basename)
+    job.fileStore.readGlobalFile(graph_id, graph_path)    
+    gam_path = os.path.join(work_dir, gam_basename)
+    job.fileStore.readGlobalFile(gam_id, gam_path)
+
+    augment_cmd = ['vg', 'augment', os.path.basename(graph_path), os.path.basename(gam_path), '-t', str(job.cores)]
+
+    # hardcoded naming convention: tack on an -aug to input paths
+    graph_name, graph_ext = os.path.splitext(graph_basename)
+    augmented_graph_path = os.path.join(work_dir, graph_name + '-aug' + graph_ext)
+    augmented_gam_path = os.path.join(work_dir, remove_ext(gam_basename, '.gam') + '-aug.gam')
+    if augment_gam:
+        augment_cmd += ['-A', os.path.basename(augmented_gam_path)]
+
+    # optional stuff
+    if min_coverage is not None:
+        augment_cmd += ['-m', str(min_coverage)]
+    if expected_coverage is not None:
+        augment_cmd += ['-c', str(expected_coverage)]
+    if min_mapq is not None:
+        augment_cmd += ['-Q', str(min_mapq)]
+    if min_baseq is not None:
+        augment_cmd += ['-q', str(min_baseq)]
+
+    # run the command
+    try:
+        with open(augmented_graph_path, 'w') as augmented_graph_file:
+            context.runner.call(job, augment_cmd, work_dir = work_dir, outfile = augmented_graph_file)
+    except Exception as e:
+        logging.error("Augment failed. Dumping input files to outstore.")
+        for dump_path in [graph_path, gam_path]:
+            if dump_path and os.path.isfile(dump_path):
+                context.write_output_file(job, dump_path)
+
+    # return the output
+    write_fn = context.write_output_file if to_outstore else context.write_intermediate_file
+    aug_graph_id = write_fn(job, augmented_graph_path)
+    aug_gam_id = write_fn(job, augmented_gam_path) if augment_gam else None
+    return aug_graph_id, aug_gam_id
+    
+def augment_main(context, options):
+    """
+    Wrapper for vg augment.
+    """
+
+    validate_chunk_options(options, chunk_optional=True)
+        
+    # How long did it take to run the entire pipeline, in seconds?
+    run_time_pipeline = None
+        
+    # Mark when we start the pipeline
+    start_time_pipeline = timeit.default_timer()
+
+    with context.get_toil(options.jobStore) as toil:
+        if not toil.options.restart:
+
+            importer = AsyncImporter(toil)
+
+            # Upload local files to the job store
+            inputGraphFileID = importer.load(options.graph)
+            inputGamFileID = None
+            if options.gam:
+                inputGamFileID = importer.load(options.gam)
+
+            importer.wait()
+
+            # Make a root job
+            root_job = Job.wrapJobFn(run_chunked_augmenting, context,
+                                     graph_id = importer.resolve(inputGraphFileID),
+                                     graph_basename = os.path.basename(options.graph),
+                                     gam_id = importer.resolve(inputGamFileID),
+                                     gam_basename = os.path.basename(options.gam),                                     
+                                     all_path_components=options.all_path_components,
+                                     chunk_paths=options.path_components,
+                                     connected_component_chunking=options.connected_components,
+                                     output_format=options.output_format,
+                                     augment_gam=options.augment_gam,
+                                     min_coverage=options.min_coverage,
+                                     expected_coverage=options.expected_coverage,
+                                     min_mapq=options.min_mapq,
+                                     min_baseq=options.min_baseq,
+                                     to_outstore=True)
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context, sys.argv,
+                                     memory=context.config.misc_mem,
+                                     disk=context.config.misc_disk)
+            init_job.addFollowOn(root_job)            
+            
+            # Run the job and store the returned list of output files to download
+            toil.start(init_job)
+        else:
+            toil.restart()
+
+    end_time_pipeline = timeit.default_timer()
+    run_time_pipeline = end_time_pipeline - start_time_pipeline
+ 
+    logger.info("All jobs completed successfully. Pipeline took {} seconds.".format(run_time_pipeline))

--- a/src/toil_vg/vg_augment.py
+++ b/src/toil_vg/vg_augment.py
@@ -47,7 +47,7 @@ def augment_subparser(parser):
     add_common_vg_parse_args(parser)
 
     # Add augment options
-    augment_parse_args(parser)
+    augment_parse_args(parser, stand_alone = True)
 
     # Add common chunking options shared with vg_chunk
     chunk_parse_args(parser)
@@ -60,8 +60,9 @@ def augment_parse_args(parser, stand_alone = False):
     """
     Define map arguments shared with mapeval and run
     """
-    parser.add_argument("--augment_gam", action="store_true",
-                        help="produce and augmented GAM")    
+    if stand_alone:
+        parser.add_argument("--augment_gam", action="store_true",
+                            help="produce and augmented GAM")    
     parser.add_argument("--min_augment_coverage", type=int, 
                         help="minimum coverage for breakpoint to be applied")
     parser.add_argument("--expected_coverage", type=int,

--- a/src/toil_vg/vg_call.py
+++ b/src/toil_vg/vg_call.py
@@ -61,7 +61,7 @@ def call_parse_args(parser):
     parser.add_argument("--ref_paths", nargs='+', default=[],
                         help="reference paths to call (and chunk) on")
     parser.add_argument("--ref_path_chunking", action="store_true",
-                        help="chunk on --reF_paths")
+                        help="chunk on --ref_paths")
     parser.add_argument("--genotype_vcf", type=make_url,
                         help="genotype the given VCF.  Input graph must contain alt paths from VCF")
     parser.add_argument("--recall", action="store_true",
@@ -510,7 +510,7 @@ def call_main(context, options):
                                          graph_basename = os.path.basename(options.graph),
                                          gam_id = importer.resolve(inputGamFileID),
                                          gam_basename = os.path.basename(options.gam),
-                                         filter_opts = options.filter_opts,
+                                         filter_opts = context.config.filter_opts,
                                          cores=context.config.calling_cores,
                                          memory=context.config.calling_mem,
                                          disk=context.config.calling_disk)

--- a/src/toil_vg/vg_calleval.py
+++ b/src/toil_vg/vg_calleval.py
@@ -32,7 +32,7 @@ from toil.common import Toil
 from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
-from toil_vg.vg_call import chunked_call_parse_args, run_all_calling, run_concat_vcfs
+from toil_vg.vg_call import call_parse_args, run_chunked_calling, run_concat_vcfs
 from toil_vg.vg_vcfeval import vcfeval_parse_args, run_vcfeval, run_vcfeval_roc_plot, run_happy, run_sv_eval
 from toil_vg.context import Context, run_write_info_to_outstore
 from toil_vg.vg_construct import run_unzip_fasta, run_make_control_vcfs
@@ -66,7 +66,7 @@ def calleval_subparser(parser):
     add_common_vg_parse_args(parser)
 
     # Add common call options shared with toil_vg pipeline
-    chunked_call_parse_args(parser)
+    call_parse_args(parser)
     
     # Add common vcfeval options shared with toil_vg pipeline
     vcfeval_parse_args(parser)

--- a/src/toil_vg/vg_chunk.py
+++ b/src/toil_vg/vg_chunk.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python2.7
+"""
+vg_chunk.py: split a graph and/or GAM into chunks by connected component
+
+"""
+from __future__ import print_function
+import argparse, sys, os, os.path, errno, random, subprocess, shutil, itertools, glob, tarfile
+import doctest, re, json, collections, time, timeit
+import logging, logging.handlers, SocketServer, struct, socket, threading
+import string
+import urlparse
+import getpass
+import pdb
+import gzip
+import logging
+
+from math import ceil
+from subprocess import Popen, PIPE
+
+from toil.common import Toil
+from toil.job import Job
+from toil.realtimeLogger import RealtimeLogger
+from toil_vg.vg_common import *
+from toil_vg.context import Context, run_write_info_to_outstore
+
+logger = logging.getLogger(__name__)
+
+def chunk_subparser(parser):
+    """
+    Create a subparser for augmenting.  Should pass in results of subparsers.add_parser()
+    """
+
+    # Add the Toil options so the job store is the first argument
+    Job.Runner.addToilOptions(parser)
+    
+    # General options
+    
+    parser.add_argument("out_store",
+                        help="output store.  All output written here. Path specified using same syntax as toil jobStore")
+        
+    # Add common options shared with everybody
+    add_common_vg_parse_args(parser)
+
+    # Add augment options
+    chunk_parse_args(parser)
+
+    # Add common docker options
+    add_container_tool_parse_args(parser)
+
+    # local main options
+    parser.add_argument("--gam", type=make_url,
+                        help="GAM to chunk")
+    parser.add_argument("--graph", type=make_url, required=True,
+                        help="graph or xg index to chunk")
+
+
+def chunk_parse_args(parser, stand_alone = False):
+    """
+    Define chunk arguments that may be shared with other commands
+    """
+
+    parser.add_argument("--connected_components", action="store_true",
+                        help="split into connected components")
+    parser.add_argument("--all_path_components", action="store_true",
+                        help="split into connected component for each path in graph")
+    parser.add_argument("--path_components", nargs="+", default=[],
+                        help="split into connected component for each given path")
+    parser.add_argument("--output_format", choices="pg, hg, vg", default="pg",
+                        help="output format [pg]")
+    
+def validate_chunk_options(options, chunk_optional=False):
+    num_opts = [options.connected_components, options.all_path_components, len(options.path_components) > 0].count(True)
+    if chunk_optional == False:
+        require(num_opts == 1,
+                "Must specify (exactly) one of --connected_components, --all_path_components or --path_components")
+    else:
+        require(num_opts in [0, 1],
+                "Must specify at most one of --connected_components, --all_path_components or --path_components")
+
+    if options.gam:
+        require(options.gam.endswith('.gam'),
+                "Input GAM file must have .gam extension")
+        
+def run_chunking(job, context,
+                 graph_id,
+                 graph_basename,
+                 chunk_paths,
+                 connected_component_chunking,
+                 output_format,
+                 gam_id = None,
+                 to_outstore = False):
+    """ thin wrapper of vg chunk.  it will return a map from path name to id of chunked file"""
+
+    work_dir = job.fileStore.getLocalTempDir()
+
+    # Read our input files from the store
+    graph_path = os.path.join(work_dir, graph_basename)
+    job.fileStore.readGlobalFile(graph_id, graph_path)
+    input_opts = ['-x', os.path.basename(graph_path)]
+    if gam_id:
+        gam_path = os.path.join(work_dir, 'aln.gam')
+        job.fileStore.readGlobalFile(gam_id, gam_path)
+        input_opts += ['-a', os.path.basename(gam_path), '-g']
+
+    paths_path = os.path.join(work_dir, 'paths.txt')        
+    if chunk_paths:
+        with open(paths_path, 'w') as path_file:
+            for chunk_path in chunk_paths:
+                path_file.write(chunk_path + '\n')
+        input_opts += ['-P', os.path.basename(paths_path)]
+
+    # output options
+    chunk_prefix = 'chunk/chunk'
+    os.makedirs(os.path.join(work_dir, os.path.dirname(chunk_prefix)))    
+    output_opts = ['-b', chunk_prefix, ]
+    output_bed_path = os.path.join(work_dir, 'chunks.bed')
+    output_opts += ['-E', os.path.basename(output_bed_path)]
+    output_opts += ['-O', output_format]
+
+    # general options
+    if connected_component_chunking or len(chunk_paths) > 0:
+        gen_opts = ['-C']
+    else:
+        gen_opts = ['-M']
+    gen_opts += ['-t', str(job.cores)]
+
+    # Run vg chunk
+    try:
+        context.runner.call(job, ['vg', 'chunk'] + gen_opts + input_opts + output_opts,
+                            work_dir = work_dir)
+    except Exception as e:
+        logging.error("Chunk failed. Dumping input files to outstore.")
+        for dump_path in [graph_path, gam_path, paths_path]:
+            if dump_path and os.path.isfile(dump_path):
+                context.write_output_file(job, dump_path)
+        
+    # Scrape the BED into dictionary that maps path name to file id
+    chunk_output = {}
+    write_fn = context.write_output_file if to_outstore else context.write_intermediate_file
+    with open(output_bed_path) as output_bed:
+        for line in output_bed:
+            toks = line.split('\t')
+            if len(toks) > 3:
+                graph_chunk_path = os.path.join(work_dir, toks[3].rstrip())
+                # be robust to the vagaries of vg chunk: deal with graph or gam extension in bed
+                if graph_chunk_path.endswith('.gam'):
+                    graph_chunk_path = remove_ext(graph_chunk_path, '.gam') + '.' + output_format
+                graph_chunk_id = write_fn(job, graph_chunk_path)
+                chunk_output[toks[0]] = [graph_chunk_id, os.path.basename(graph_chunk_path)]
+                if gam_id:
+                    gam_chunk_path = os.path.join(work_dir, toks[3].rstrip())
+                    if not gam_chunk_path.endswith('.gam'):
+                        gam_chunk_path = remove_ext(gam_chunk_path, '.' + output_format) + '.gam'
+                    gam_chunk_id = write_fn(job, gam_chunk_path)
+                    chunk_output[toks[0]] += [gam_chunk_id, os.path.basename(gam_chunk_path)]
+
+    return chunk_output
+    
+    
+def chunk_main(context, options):
+    """ entrypoint for calling """
+
+    validate_chunk_options(options)
+            
+    # How long did it take to run the entire pipeline, in seconds?
+    run_time_pipeline = None
+        
+    # Mark when we start the pipeline
+    start_time_pipeline = timeit.default_timer()
+    
+    with context.get_toil(options.jobStore) as toil:
+        if not toil.options.restart:
+
+            importer = AsyncImporter(toil)
+
+            # Upload local files to the job store
+            inputGraphFileID = importer.load(options.graph)
+            inputGamFileID = None
+            if options.gam:
+                inputGamFileID = importer.load(options.gam)
+
+            importer.wait()
+
+            # Make a root job
+            root_job = Job.wrapJobFn(run_chunking, context,
+                                     importer.resolve(inputGraphFileID),
+                                     os.path.basename(options.graph),
+                                     chunk_paths=options.path_components,
+                                     connected_component_chunking=options.connected_components,
+                                     output_format=options.output_format,
+                                     gam_id = importer.resolve(inputGamFileID),
+                                     to_outstore = True,
+                                     cores=context.config.call_chunk_cores,
+                                     memory=context.config.call_chunk_mem,
+                                     disk=context.config.call_chunk_disk)
+
+            # Init the outstore
+            init_job = Job.wrapJobFn(run_write_info_to_outstore, context, sys.argv,
+                                     memory=context.config.misc_mem,
+                                     disk=context.config.misc_disk)
+            init_job.addFollowOn(root_job)            
+            
+            # Run the job and store the returned list of output files to download
+            toil.start(init_job)
+        else:
+            toil.restart()
+                
+    end_time_pipeline = timeit.default_timer()
+    run_time_pipeline = end_time_pipeline - start_time_pipeline
+ 
+    logger.info("All jobs completed successfully. Pipeline took {} seconds.".format(run_time_pipeline))
+    
+    

--- a/src/toil_vg/vg_chunk.py
+++ b/src/toil_vg/vg_chunk.py
@@ -66,9 +66,9 @@ def chunk_parse_args(parser, path_components=True):
                             help="split into connected component for each given path")
     parser.add_argument("--output_format", choices="pg, hg, vg", default="pg",
                         help="output format [pg]")
-    parser.add_argument("--call_chunk_cores", type=int,
+    parser.add_argument("--chunk_cores", type=int,
                         help="number of threads used for extracting chunks for calling")
-    parser.add_argument("--call_chunk_mem", type=str,
+    parser.add_argument("--chunk_mem", type=str,
                         help="memory alotment for extracting chunks for calling")
 
     
@@ -114,7 +114,7 @@ def run_chunking(job, context,
         input_opts += ['-P', os.path.basename(paths_path)]
 
     # output options
-    chunk_prefix = 'chunk/chunk'
+    chunk_prefix = 'chunk/{}'.format(os.path.splitext(graph_basename)[0])
     os.makedirs(os.path.join(work_dir, os.path.dirname(chunk_prefix)))    
     output_opts = ['-b', chunk_prefix, ]
     output_bed_path = os.path.join(work_dir, 'chunks.bed')
@@ -195,9 +195,9 @@ def chunk_main(context, options):
                                      output_format=options.output_format,
                                      gam_id = importer.resolve(inputGamFileID),
                                      to_outstore = True,
-                                     cores=context.config.call_chunk_cores,
-                                     memory=context.config.call_chunk_mem,
-                                     disk=context.config.call_chunk_disk)
+                                     cores=context.config.chunk_cores,
+                                     memory=context.config.chunk_mem,
+                                     disk=context.config.chunk_disk)
 
             # Init the outstore
             init_job = Job.wrapJobFn(run_write_info_to_outstore, context, sys.argv,

--- a/src/toil_vg/vg_common.py
+++ b/src/toil_vg/vg_common.py
@@ -753,15 +753,21 @@ def parse_id_ranges_file(id_ranges_filename):
                 id_ranges.append((toks[0], int(toks[1]), int(toks[2])))
     return id_ranges
 
-def remove_ext(string, ext):
+def remove_ext(string, ext=None):
     """
     Strip a suffix from a string. Case insensitive.
+    If no suffix given, strips the last . and everything after (like file extension)
     """
-    # See <https://stackoverflow.com/a/18723694>
+    if ext is None:
+        if string.rfind('.') >= 0:
+            ext = string[string.rfind('.'):]
+        else:
+            ext =""
     if string.lower().endswith(ext.lower()):
         return string[:-len(ext)]
     else:
         return string
+        
 
 def truncate_msg(msg, max_len=2000):
     """

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -114,11 +114,15 @@ alignment-mem: '4G'
 alignment-disk: '2G'
 
 # Resources for chunking up a graph/gam for calling (and merging)
-# typically take xg for whoe grpah, and gam for a chromosome,
-# and split up into chunks of call-chunk-size (below)
-call-chunk-cores: 1
-call-chunk-mem: '4G'
-call-chunk-disk: '2G'
+# typically take xg for whoe grpah, and gam for a chromosome
+chunk-cores: 1
+chunk-mem: '4G'
+chunk-disk: '2G'
+
+# Resources for augmenting a graph
+augment-cores: 1
+augment-mem: '4G'
+augment-disk: '2G'
 
 # Resources for calling each chunk (currently includes augment/call/genotype)
 calling-cores: 1
@@ -256,46 +260,18 @@ msga-context: 50
 
 #########################
 ### vg_call Arguments ###
-# Overlap option that is passed into make_chunks and call_chunk
-overlap: 2000
-
-# Chunk size (set to 0 to disable chunking)
-call-chunk-size: 2000000
-
-# Context expansion used for graph chunking
-chunk_context: 50
 
 # Options to pass to vg filter when running vg call. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
-
-# Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
-# Also used with --genotype_vcf
-recall-filter-opts: []
+filter-opts: []
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
-augment-opts: ['-q', '10']
+augment-opts: []
 
 # Options to pass to vg pack. (do not include any file names or -t/--threads)
-pack-opts: ['-Q', '15']
+pack-opts: []
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
-call-opts: ['-e', '10']
-
-# Options to pass to vg call when using --recall. (do not include file/contig/sample names or -t/--threads)
-# Also used with --genotype_vcf
-recall-opts: ['-u', '-n', '0', '-e', '1000', '-G', '3']
-
-# Override chunk context when using --recall or --genotype_vcf
-recall-context: 2500
-
-# Options to pass to vg genotype. (do not include file/contig/sample names or -t/--threads)
-genotype-opts: []
-
-# Use vg genotype instead of vg call
-genotype: False
-
-# If input GAMs needed to be sorted, save a copy of the sorted version in the output store
-keep-sorted-gams: False
+call-opts: []
 
 #########################
 ### vcfeval Arguments ###
@@ -409,11 +385,15 @@ alignment-mem: '100G'
 alignment-disk: '100G'
 
 # Resources for chunking up a graph/gam for calling (and merging)
-# typically take xg for whoe grpah, and gam for a chromosome,
-# and split up into chunks of call-chunk-size (below)
-call-chunk-cores: 16
-call-chunk-mem: '100G'
-call-chunk-disk: '100G'
+# typically take xg for whoe grpah, and gam for a chromosome
+chunk-cores: 16
+chunk-mem: '100G'
+chunk-disk: '100G'
+
+# Resources for augmenting a graph
+augment-cores: 8
+augment-mem: '64G'
+augment-disk: '64G'
 
 # Resources for calling each chunk (currently includes augment/call/genotype)
 calling-cores: 4
@@ -551,46 +531,18 @@ msga-context: 2000
 
 #########################
 ### vg_call Arguments ###
-# Overlap option that is passed into make_chunks and call_chunk
-overlap: 100000
-
-# Chunk size (set to 0 to disable chunking)
-call-chunk-size: 2500000
-
-# Context expansion used for graph chunking
-chunk_context: 50
 
 # Options to pass to vg filter when running vg call. (do not include file names or -t/--threads)
-filter-opts: ['-r', '0.9', '-fu', '-s', '1000', '-m', '1', '-q', '15', '-D', '999']
-
-# Options to pass to vg filter when using --recall. (do not include file names or -t/--threads)
-# Also used with --genotype_vcf
-recall-filter-opts: []
+filter-opts: []
 
 # Options to pass to vg augment. (do not include any file names or -t/--threads or -a/--augmentation-mode)
-augment-opts: ['-q', '10']
+augment-opts: []
 
 # Options to pass to vg pack. (do not include any file names or -t/--threads)
-pack-opts: ['-Q', '15']
+pack-opts: []
 
 # Options to pass to vg call. (do not include file/contig/sample names or -t/--threads)
-call-opts: ['-e', '10']
-
-# Options to pass to vg call when using --recall. (do not include file/contig/sample names or -t/--threads)
-# Also used with --genotype_vcf
-recall-opts: ['-u', '-n', '0', '-e', '1000', '-G', '3']
-
-# Override chunk context when using --recall or --genotype_vcf
-recall-context: 2500
-
-# Options to pass to vg genotype. (do not include file/contig/sample names or -t/--threads)
-genotype-opts: []
-
-# Use vg genotype instead of vg call
-genotype: False
-
-# If input GAMs needed to be sorted, save a copy of the sorted version in the output store
-keep-sorted-gams: False
+call-opts: []
 
 #########################
 ### vcfeval Arguments ###

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -153,7 +153,7 @@ container: """ + (default_container) + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.20.0'
+vg-docker: 'quay.io/vgteam/vg:v1.20.0-134-gc29c4a250-t347-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'
@@ -448,7 +448,7 @@ container: """ + (default_container) + """
 ##   of through docker. 
 
 # Docker image to use for vg
-vg-docker: 'quay.io/vgteam/vg:v1.20.0'
+vg-docker: 'quay.io/vgteam/vg:v1.20.0-134-gc29c4a250-t347-run'
 
 # Docker image to use for bcftools
 bcftools-docker: 'quay.io/biocontainers/bcftools:1.9--h4da6232_0'

--- a/src/toil_vg/vg_construct.py
+++ b/src/toil_vg/vg_construct.py
@@ -1454,7 +1454,7 @@ def run_make_haplo_thread_graphs(job, context, vg_id, vg_name, output_name, chro
                 logger.info('Creating thread graph {}'.format(vg_with_thread_as_path_path))
                 with open(vg_with_thread_as_path_path, 'w') as thread_only_file:
                     # strip paths from our original graph            
-                    cmd = ['vg', 'mod', '-D', os.path.basename(vg_path)]
+                    cmd = ['vg', 'paths', '-d', '-v', os.path.basename(vg_path)]
                     context.runner.call(job, cmd, work_dir = work_dir, outfile = thread_only_file)
 
                     # get haplotype thread paths from the gbwt
@@ -1470,9 +1470,9 @@ def run_make_haplo_thread_graphs(job, context, vg_id, vg_name, output_name, chro
                 # Then we trim out anything other than our thread path
                 cmd = [['vg', 'mod', '-N', os.path.basename(vg_with_thread_as_path_path)]]
                 # And get rid of our thread paths since they take up lots of space when re-indexing
-                filter_cmd = ['vg', 'mod', '-']
+                filter_cmd = ['vg', 'paths', '-v', '-']
                 for chrom in chroms:
-                    filter_cmd += ['-r', chrom]
+                    filter_cmd += ['--retain-paths', chrom]
                 cmd.append(filter_cmd)
                 context.runner.call(job, cmd, work_dir = work_dir, outfile = trimmed_file)
 
@@ -1577,7 +1577,7 @@ def run_make_sample_region_graph(job, context, vg_id, vg_name, output_name, chro
         logger.info('Creating sample extraction graph {}'.format(extract_graph_path))
         with open(extract_graph_path, 'w') as extract_graph_file:
             # strip paths from our original graph            
-            cmd = ['vg', 'mod', '-D', os.path.basename(vg_path)]
+            cmd = ['vg', 'paths', '-d', '-v', os.path.basename(vg_path)]
             context.runner.call(job, cmd, work_dir = work_dir, outfile = extract_graph_file)
 
             for hap in haplotypes:
@@ -1596,7 +1596,7 @@ def run_make_sample_region_graph(job, context, vg_id, vg_name, output_name, chro
         # Then we trim out anything other than our thread paths
         cmd = [['vg', 'mod', '-N', os.path.basename(extract_graph_path)]]
         if not leave_thread_paths:
-            cmd.append(['vg', 'mod', '-', '-D'])
+            cmd.append(['vg', 'paths', '-v', '-', '-d'])
         context.runner.call(job, cmd, work_dir = work_dir, outfile = sample_graph_file)
         
     if validate:

--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -1007,15 +1007,15 @@ def run_alt_path_extraction(job, context, inputGraphFileIDs, graph_names, index_
             # For each input graph, make a child job to index it.
             sub_jobs.append(job.addChildJobFn(run_alt_path_extraction, context, [file_id], [file_name],
                                               index_name + '.{}'.format(i) if index_name else None,
-                                              cores=context.config.call_chunk_cores,
-                                              memory=context.config.call_chunk_mem,
-                                              disk=context.config.call_chunk_disk))
+                                              cores=context.config.chunk_cores,
+                                              memory=context.config.chunk_mem,
+                                              disk=context.config.chunk_disk))
         
         # Make a job to concatenate the indexes all together                                        
         concat_job = sub_jobs[0].addFollowOnJobFn(run_concat_files, context, [job.rv() for job in sub_jobs],
                                                   index_name + '_alts.gam' if index_name is not None else None,
-                                                  memory=context.config.call_chunk_mem,
-                                                  disk=context.config.call_chunk_disk)
+                                                  memory=context.config.chunk_mem,
+                                                  disk=context.config.chunk_disk)
         
         for i in xrange(1, len(sub_jobs)):
             # And make it wait for all of them
@@ -1399,9 +1399,9 @@ def run_indexing(job, context, inputGraphFileIDs,
     if 'alt-gam' in wanted:
         alt_extract_job = child_job.addChildJobFn(run_alt_path_extraction, context, inputGraphFileIDs,
                                                   graph_names, None,
-                                                  cores=context.config.call_chunk_cores,
-                                                  memory=context.config.call_chunk_mem,
-                                                  disk=context.config.call_chunk_disk)
+                                                  cores=context.config.chunk_cores,
+                                                  memory=context.config.chunk_mem,
+                                                  disk=context.config.chunk_disk)
         
         indexes['alt-gam'] = alt_extract_job.addFollowOnJobFn(run_gam_indexing, context, alt_extract_job.rv(),
                                                               index_name,

--- a/src/toil_vg/vg_map.py
+++ b/src/toil_vg/vg_map.py
@@ -43,8 +43,6 @@ def map_subparser(parser):
                         help="output store.  All output written here. Path specified using same syntax as toil jobStore")
     parser.add_argument("--kmer_size", type=int,
                         help="size of kmers to use in gcsa-kmer mapping mode")
-    parser.add_argument("--id_ranges", type=make_url, default=None,
-                        help="Path to file with node id ranges for each chromosome in BED format.")
         
     # Add common options shared with everybody
     add_common_vg_parse_args(parser)
@@ -112,6 +110,9 @@ def map_parse_args(parser, stand_alone = False):
                         help="surject output, producing BAM in addition to GAM alignments")
     parser.add_argument("--validate", action="store_true",
                         help="run vg validate on ouput GAMs")
+    parser.add_argument("--id_ranges", type=make_url, default=None,
+                        help="Path to file with node id ranges for each chromosome in BED format.")
+
     
 def validate_map_options(context, options):
     """

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -166,7 +166,7 @@ def pipeline_subparser(parser_run):
     map_parse_index_args(parser_run)
     
     # Add common calling options shared with vg_call
-    chunked_call_parse_args(parser_run)
+    call_parse_args(parser_run)
 
     # Add common calling options shared with vg_vcfeval
     vcfeval_parse_args(parser_run)

--- a/src/toil_vg/vg_toil.py
+++ b/src/toil_vg/vg_toil.py
@@ -45,6 +45,8 @@ from toil_vg.context import Context, run_write_info_to_outstore
 from toil_vg.vg_construct import *
 from toil_vg.vg_surject import *
 from toil_vg.vg_msga import *
+from toil_vg.vg_chunk import *
+from toil_vg.vg_augment import *
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +122,14 @@ def parse_args(args=None):
     parser_msga = subparsers.add_parser('msga', help='Align fasta sequences to a graph')
     msga_subparser(parser_msga)
 
+    # chunk subparser
+    parser_chunk = subparsers.add_parser('chunk', help='Split a graph into components')
+    chunk_subparser(parser_chunk)
+
+    # augment subparser
+    parser_augment = subparsers.add_parser('augment', help='Augment a graph with variation from a GAM')
+    augment_subparser(parser_augment)
+    
     # version subparser
     parser_version = subparsers.add_parser('version', help='Print version')
 
@@ -407,6 +417,10 @@ def main():
         plot_main(context, args)
     elif args.command == 'msga':
         msga_main(context, args)
+    elif args.command == 'chunk':
+        chunk_main(context, args)
+    elif args.command == 'augment':
+        augment_main(context, args)
     else:
         raise RuntimeError('Unimplemented subcommand {}'.format(args.command))
         

--- a/src/toil_vg/vg_vcfeval.py
+++ b/src/toil_vg/vg_vcfeval.py
@@ -14,7 +14,6 @@ from toil.job import Job
 from toil.realtimeLogger import RealtimeLogger
 from toil_vg.vg_common import *
 from toil_vg.context import Context, run_write_info_to_outstore
-from toil_vg.vg_call import sort_vcf
 from toil_vg.vg_construct import run_make_control_vcfs
 
 logger = logging.getLogger(__name__)
@@ -104,6 +103,16 @@ def validate_vcfeval_options(options):
     assert not options.normalize or options.vcfeval_fasta
     assert not options.normalize_calls or options.vcfeval_fasta
     assert not options.normalize_baseline or options.vcfeval_fasta
+
+def sort_vcf(job, drunner, vcf_path, sorted_vcf_path):
+    """ from vcflib """
+    vcf_dir, vcf_name = os.path.split(vcf_path)
+    with open(sorted_vcf_path, "w") as outfile:
+        drunner.call(job, [['bcftools', 'view', '-h', vcf_name]], outfile=outfile,
+                     work_dir=vcf_dir)
+        drunner.call(job, [['bcftools', 'view', '-H', vcf_name],
+                      ['sort', '-k1,1d', '-k2,2n']], outfile=outfile,
+                     work_dir=vcf_dir)
 
 def parse_f1(summary_path):
     """ grab the best f1 out of vcfeval's summary.txt """


### PR DESCRIPTION
`toil-vg call` has become increasingly convoluted as the underlying vg commands have changed and evolved.  There are too many options and possible control flows to maintain, especially when they are pretty much all obsolete.  For example, when `toil-vg call` was written, `vg call` couldn't be run on a graph with much more than 10 megabases.  Now it scales to a whole human genome.  So this is a near-total rewrite and simplification.  Some changes:

* only support chunking based on connected components.  (ie get rid of path-subrange and id-range chunking)
* make toggling chunking on and off easier
* make toggling between calling and genotyping easier
* only support packed calling (as implemented in latest `vg call`)
* do not support `vg genotype`
* support different input and intermeidate formats (such as packed graph)
* support other features from latest `vg augment`
* add `toil-vg chunk` and `toil-vg augment` subcommands 

Should resolve #754, #737, #519, #416, #191