### PR TITLE
Set up CI to run on Kubernetes-based runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,20 @@
+image: quay.io/vgteam/dind
+
 before_script:
   - whoami
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
   - sudo apt-get -q -y install docker.io python3-pip python-virtualenv libcurl4-gnutls-dev libgnutls28-dev python3-dev 
+  - startdocker || true
   - docker info
   # Build .pypirc with PyPI credentials
   - touch ~/.pypirc
   - chmod 600 ~/.pypirc
   - 'printf "[distutils]\nindex-servers =\n    pypi\n\n[pypi]\nusername: ${PYPI_USERNAME}\npassword: ${PYPI_PASSWORD}\n" > ~/.pypirc'
-  
+
+after_script:
+  - stopdocker || true
+
 stages:
   - test
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ pypi: check_venv check_clean_working_copy check_running_on_ci
 		from version import version as v;\
 		from pkg_resources import parse_version as pv;\
 		import os;\
-		print "--tag-build=.dev" + os.getenv("CI_PIPELINE_IID") if pv(v).is_prerelease else ""'` \
+		print("--tag-build=.dev" + os.getenv("CI_PIPELINE_IID") if pv(v).is_prerelease else "")'` \
 	&& $(python) setup.py egg_info $$tag_build sdist bdist_egg upload )
 clean_pypi:
 	- rm -rf build/


### PR DESCRIPTION
We need to make sure to start and stop Docker ourselves, because Kubernetes ignores ENTRYPOINT.