### PR TITLE
strtobool lives in a distutils.util submodule

### DIFF
--- a/src/toil_vg/vg_index.py
+++ b/src/toil_vg/vg_index.py
@@ -5,7 +5,7 @@ vg_index.py: index a graph so it can be mapped to
 """
 
 import argparse, sys, os, os.path, errno, random, subprocess, shutil, itertools, glob, tarfile
-import doctest, re, json, collections, time, timeit, distutils
+import doctest, re, json, collections, time, timeit, distutils.util
 import logging, logging.handlers, struct, socket, threading
 import string
 import getpass


### PR DESCRIPTION
We try and `import distutils` and then use `distutils.util.strtobool` which doesn't work because we haven't imported the `distutils.util` module.

This may be a Python2/3 issue relating to distutils' organization.