### PR TITLE
Use os.makedirs(exits_ok=True) for Toil mkdir_p

### DIFF
--- a/src/toil_vg/singularity.py
+++ b/src/toil_vg/singularity.py
@@ -22,8 +22,6 @@ import sys
 import tempfile
 import time
 
-from toil.lib.misc import mkdir_p
-
 logger = logging.getLogger(__name__)
 
 if sys.version_info[0] < 3:
@@ -186,7 +184,7 @@ def _singularity(job,
     
     # As a workaround, we have out own cache which we manage ourselves.
     cache_dir = os.path.join(os.environ.get('SINGULARITY_CACHEDIR',  os.path.join(os.environ.get('HOME'), '.singularity')), 'toil')
-    mkdir_p(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
     
     # What Singularity url/spec do we want?
     source_image = _convertImageSpec(tool) 


### PR DESCRIPTION
Toil is going to remove mkdir_p since Python 3.2+ has that functionality built in now.