### PR TITLE
Use a jq that should come as a v2 manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 /src/*.egg-info
 .cache/
+.pytest_cache/
 .eggs/
 test-report.xml
 __pycache__

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,18 @@ before_script:
   - whoami
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  # Also Singularity from the repos which is now new enough
-  - sudo apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev singularity-container
+  - sudo apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev
+  # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
+  # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
+  - sudo apt-get -q -y install wget libarchive-dev squashfs-tools
+  - wget https://github.com/singularityware/singularity/releases/download/2.6.1/singularity-2.6.1.tar.gz
+  - tar xf singularity-2.6.1.tar.gz
+  - pushd singularity-2.6.1
+  - ./configure --prefix=/usr/local > /dev/null
+  - make > /dev/null
+  - sudo make install > /dev/null
+  - popd
+  - rm -rf singularity-2.6.1.tar.gz singularity-2.6.1 
   # TODO: Make Singularity use the Docker cache with a wrapper like Toil will.
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
   # Set the registry as insecure because it is probably cluster-internal over plain HTTP.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,9 @@
 image: quay.io/vgteam/dind
 
+variables:
+  PYTHONIOENCODING: "utf-8"
+  DEBIAN_FRONTEND: "noninteractive"
+
 before_script:
   - whoami
   - sudo apt-get -q -y update

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev libgpgme11-dev libseccomp-dev cryptsetup-bin
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev libgpgme11-dev libseccomp-dev cryptsetup-bin pkg-config
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,23 +1,20 @@
 image: quay.io/vgteam/dind
 
-variables:
-  PYTHONIOENCODING: "utf-8"
-  DEBIAN_FRONTEND: "noninteractive"
-
 before_script:
   - whoami
-  - sudo apt-get -q -y update
+  - export DEBIAN_FRONTEND=noninteractive
+  - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - sudo apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
-  - sudo apt-get -q -y install wget libarchive-dev squashfs-tools
+  - apt-get -q -y install wget libarchive-dev squashfs-tools
   - wget https://github.com/singularityware/singularity/releases/download/2.6.1/singularity-2.6.1.tar.gz
   - tar xf singularity-2.6.1.tar.gz
   - pushd singularity-2.6.1
   - ./configure --prefix=/usr/local > /dev/null
   - make > /dev/null
-  - sudo make install > /dev/null
+  - make install > /dev/null
   - popd
   - rm -rf singularity-2.6.1.tar.gz singularity-2.6.1 
   # TODO: Make Singularity use the Docker cache with a wrapper like Toil will.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,20 +9,32 @@ before_script:
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools
-  - wget https://github.com/singularityware/singularity/releases/download/2.6.1/singularity-2.6.1.tar.gz
-  - tar xf singularity-2.6.1.tar.gz
-  - pushd singularity-2.6.1
-  - ./configure --prefix=/usr/local > /dev/null
-  - make > /dev/null
-  - make install > /dev/null
+  - wget -q https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+  - tar xf go1.13.3.linux-amd64.tar.gz
+  - rm go1.13.3.linux-amd64.tar.gz
+  - mv go/bin/* /usr/bin/
+  - mv go /usr/local/
+  - mkdir -p $(go env GOPATH)/src/github.com/sylabs
+  - pushd $(go env GOPATH)/src/github.com/sylabs
+  - git clone https://github.com/sylabs/singularity.git
+  - cd singularity
+  - git checkout v3.4.2 
+  - ./mconfig
+  - cd ./builddir
+  - make -j8
+  - make install
   - popd
-  - rm -rf singularity-2.6.1.tar.gz singularity-2.6.1 
+  - mkdir -p /usr/local/libexec/toil
+  - mv /usr/local/bin/singularity /usr/local/libexec/toil/singularity-real
+  - curl -sSL https://raw.githubusercontent.com/DataBiosphere/toil/e556fa059df029366de237566237584df6a49630/docker/singularity-wrapper.sh >/usr/local/bin/singularity
+  - chmod 755 /usr/local/bin/singularity
   # TODO: Make Singularity use the Docker cache with a wrapper like Toil will.
   # Configure Docker to use a mirror for Docker Hub and restart the daemon
   # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
   - |
     if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
         echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+        export SINGULARITY_DOCKER_HUB_MIRROR="${DOCKER_HUB_MIRROR}"
     fi
   - startdocker || true
   - docker info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,18 +4,15 @@ before_script:
   - whoami
   - sudo apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - sudo apt-get -q -y install docker.io python3-pip python-virtualenv libcurl4-gnutls-dev libgnutls28-dev python3-dev 
-  # apt-get install singularity-container installs 2.4.2 which is too old to use, so we install from source
-  # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
-  - sudo apt-get -q -y install wget libarchive-dev squashfs-tools
-  - wget https://github.com/singularityware/singularity/releases/download/2.6.1/singularity-2.6.1.tar.gz
-  - tar xf singularity-2.6.1.tar.gz
-  - pushd singularity-2.6.1
-  - ./configure --prefix=/usr/local > /dev/null
-  - make > /dev/null
-  - sudo make install > /dev/null
-  - popd
-  - rm -rf singularity-2.6.1.tar.gz singularity-2.6.1 
+  # Also Singularity from the repos which is now new enough
+  - sudo apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev singularity-container
+  # TODO: Make Singularity use the Docker cache with a wrapper like Toil will.
+  # Configure Docker to use a mirror for Docker Hub and restart the daemon
+  # Set the registry as insecure because it is probably cluster-internal over plain HTTP.
+  - |
+    if [[ ! -z "${DOCKER_HUB_MIRROR}" ]] ; then
+        echo "{\"registry-mirrors\": [\"${DOCKER_HUB_MIRROR}\"], \"insecure-registries\": [\"${DOCKER_HUB_MIRROR##*://}\"]}" | sudo tee /etc/docker/daemon.json
+    fi
   - startdocker || true
   - docker info
   # Build .pypirc with PyPI credentials

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev libgpgme11-dev libseccomp-dev
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -q -y update
   # Make sure we have some curl stuff for pycurl which we need for some Python stuff
-  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev libgpgme11-dev libseccomp-dev
+  - apt-get -q -y install --no-upgrade docker.io python3-pip python3-virtualenv libcurl4-gnutls-dev python-dev libgnutls28-dev libssl-dev uuid-dev libgpgme11-dev libseccomp-dev cryptsetup-bin
   # Ubuntu 20.04 doesn't seem to ship singularity, so we install from source
   # https://stackoverflow.com/questions/50537404/error-called-singularity-config-get-value-on-uninitialized-config-subsystem-wh
   - apt-get -q -y install wget libarchive-dev squashfs-tools

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ prepare: check_venv
 	# TODO scikit-learn can't even begin to install unless numpy is already there, so numpy has to be first and by itself.
 	# See https://github.com/scikit-learn/scikit-learn/issues/4164
 	$(pip) install scipy scikit-learn
-	$(pip) install pytest==2.8.3 'toil[aws,mesos]==3.24.0' biopython==1.67 pyvcf==0.6.8
+	$(pip) install pytest 'toil[aws,mesos]==4.1.0' biopython pyvcf
 	pip list
 clean_prepare: check_venv
 	$(pip) uninstall -y pytest biopython numpy scipy scikit-learn pyvcf

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ clean_prepare: check_venv
 	$(pip) uninstall -y pytest biopython numpy scipy scikit-learn pyvcf
 
 check_venv:
-	@$(python) -c 'import sys; sys.exit( int( not hasattr(sys, "real_prefix") ) )' \
+	@$(python) -c 'import sys, os; sys.exit( int( 0 if "VIRTUAL_ENV" in os.environ else 1 ) )' \
 		|| ( echo "$(red)A virtualenv must be active.$(normal)" ; false )
 
 

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,10 @@ check_build_reqs:
 
 
 prepare: check_venv
-	# TODO: numpy cannot build from source correctly on some systems, and installing in a virtualenv fails with --only-binary :all:
-	$(pip) install numpy==1.17.1
+	$(pip) install numpy
 	# TODO scikit-learn can't even begin to install unless numpy is already there, so numpy has to be first and by itself.
 	# See https://github.com/scikit-learn/scikit-learn/issues/4164
-	$(pip) install scipy scikit-learn==0.22.1
+	$(pip) install scipy scikit-learn
 	$(pip) install pytest==2.8.3 'toil[aws,mesos]==3.24.0' biopython==1.67 pyvcf==0.6.8
 	pip list
 clean_prepare: check_venv

--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,7 @@
 
 # Create Toil venv
 rm -rf .env
-virtualenv -p python3.6 --never-download .env
+virtualenv -p python3 --never-download .env
 . .env/bin/activate
 
 # Upgrade pip3
@@ -14,7 +14,7 @@ set -e
 
 # Create s3am venv
 rm -rf s3am
-virtualenv -p python3.6 --never-download s3am && s3am/bin/pip3 install s3am==2.0
+virtualenv -p python3 --never-download s3am && s3am/bin/pip3 install s3am==2.0
 mkdir -p bin
 # Expose binaries to the PATH
 ln -snf ${PWD}/s3am/bin/s3am bin/
@@ -22,7 +22,7 @@ export PATH=$PATH:${PWD}/bin
 
 # Create awscli venv
 rm -rf awscli
-virtualenv -p python3.6 --never-download awscli && awscli/bin/pip3 install awscli
+virtualenv -p python3 --never-download awscli && awscli/bin/pip3 install awscli
 # Expose binaries to the PATH
 ln -snf ${PWD}/awscli/bin/aws bin/
 export PATH=$PATH:${PWD}/bin

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class PyTest(TestCommand):
         import pytest
         # Sanitize command line arguments to avoid confusing Toil code attempting to parse them
         sys.argv[1:] = []
-        errno = pytest.main(self.pytest_args)
+        errno = pytest.main(self.pytest_args.split())
         sys.exit(errno)
 
 kwargs['cmdclass'] = {'test': PyTest}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ kwargs = dict(
     python_requires='>=3.0',
     install_requires=[x + y for x, y in required_versions.items()],
     dependency_links=[],
-    tests_require=['pytest==2.8.3', 'numpy', 'scipy'],
+    tests_require=['pytest', 'numpy', 'scipy'],
     package_dir={'': 'src'},
     packages=find_packages('src'),
     entry_points={

--- a/src/toil_vg/vg_config.py
+++ b/src/toil_vg/vg_config.py
@@ -174,7 +174,7 @@ bwa-docker: 'quay.io/ucsc_cgl/bwa:latest'
 minimap2-docker: 'evolbioinfo/minimap2:v2.14'
 
 # Docker image to use for jq
-jq-docker: 'devorbitus/ubuntu-bash-jq-curl'
+jq-docker: 'celfring/jq'
 
 # Docker image to use for rtg
 rtg-docker: 'realtimegenomics/rtg-tools:3.8.4'
@@ -481,7 +481,7 @@ bwa-docker: 'quay.io/ucsc_cgl/bwa:latest'
 minimap2-docker: 'evolbioinfo/minimap2:v2.14'
 
 # Docker image to use for jq
-jq-docker: 'devorbitus/ubuntu-bash-jq-curl'
+jq-docker: 'celfring/jq'
 
 # Docker image to use for rtg
 rtg-docker: 'realtimegenomics/rtg-tools:3.8.4'


### PR DESCRIPTION
The old one is A) based on Ubuntu 14.04 and B) a v1 Docker manifest that our CI can't cache, so we run out of pulls.