### PR TITLE
Point at new, more permanent data home

### DIFF
--- a/scripts/construct_bakeoff_graphs.py
+++ b/scripts/construct_bakeoff_graphs.py
@@ -4,7 +4,8 @@ Locally regenerate all the bakeoff regions graphs and indexes that are
 found here s3://vg-data/bakeoff/
 The input fasta's and vcf's are expected to be there already.
 Assumes you have authenticated S3 access configured. If not, the files are
-mirrored to https://public.gi.ucsc.edu/~anovak/vg-data/bakeoff/ 
+mirrored to https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/bakeoff/ and you can
+use those. 
 """
 
 import os, sys, subprocess

--- a/src/toil_vg/test/test_vg.py
+++ b/src/toil_vg/test/test_vg.py
@@ -40,9 +40,9 @@ class VGCGLTest(TestCase):
         Get the URL from which an input file can be obtained.
         """
         # /public/groups/vg/vg-data on Courtyard is served as
-        # https://public.gi.ucsc.edu/~anovak/vg-data/. These are also the
+        # https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/. These are also the
         # files from the s3://vg-data bucket.
-        return 'https://public.gi.ucsc.edu/~anovak/vg-data/toil_vg_ci/{}'.format(filename)
+        return 'https://public.gi.ucsc.edu/cgl/ci/vg/vg-data/toil_vg_ci/{}'.format(filename)
     
     def _download_input(self, filename, local_path = None):
         # Where should we put this input file?


### PR DESCRIPTION
The user-level data web directory we were using for test data is moving.

This points at a new, group-scoped data directory that should be more permanent.